### PR TITLE
Solved navigation issue between edit and view screen

### DIFF
--- a/micro-ui/web/micro-ui-internals/packages/modules/workbench/src/pages/employee/MDMSEdit.js
+++ b/micro-ui/web/micro-ui-internals/packages/modules/workbench/src/pages/employee/MDMSEdit.js
@@ -1,32 +1,32 @@
-import React,{useState} from 'react'
-import MDMSAdd from './MDMSAddV2'
-import { Loader,Toast } from '@egovernments/digit-ui-react-components';
+import React, { useState } from "react";
+import MDMSAdd from "./MDMSAddV2";
+import { Loader, Toast } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
-const MDMSEdit = ({...props}) => {
-  const history = useHistory()
+const MDMSEdit = ({ ...props }) => {
+  const history = useHistory();
 
-  const { t } = useTranslation()
+  const { t } = useTranslation();
 
-  const { moduleName, masterName, tenantId,uniqueIdentifier } = Digit.Hooks.useQueryParams();
+  const { moduleName, masterName, tenantId, uniqueIdentifier } = Digit.Hooks.useQueryParams();
   const stateId = Digit.ULBService.getCurrentTenantId();
 
   const [showToast, setShowToast] = useState(false);
-  const [renderLoader,setRenderLoader] = useState(false)
+  const [renderLoader, setRenderLoader] = useState(false);
   const reqCriteria = {
     url: `/${Digit.Hooks.workbench.getMDMSContextPath()}/v2/_search`,
     params: {},
     body: {
       MdmsCriteria: {
         tenantId: stateId,
-        uniqueIdentifiers:[uniqueIdentifier],
-        schemaCode:`${moduleName}.${masterName}`
+        uniqueIdentifiers: [uniqueIdentifier],
+        schemaCode: `${moduleName}.${masterName}`,
       },
     },
     config: {
       enabled: moduleName && masterName && true,
       select: (data) => {
-        return data?.mdms?.[0]
+        return data?.mdms?.[0];
       },
     },
   };
@@ -37,44 +37,41 @@ const MDMSEdit = ({...props}) => {
     body: {
       SchemaDefCriteria: {
         tenantId: stateId,
-        codes:[`${moduleName}.${masterName}`]
+        codes: [`${moduleName}.${masterName}`],
       },
     },
     config: {
       enabled: moduleName && masterName && true,
-      select: (data) => { 
-        const uniqueFields = data?.SchemaDefinitions?.[0]?.definition?.["x-unique"]
-        const updatesToUiSchema = {}
-        uniqueFields.forEach(field => updatesToUiSchema[field] = {"ui:readonly":true})
-        return {schema:data?.SchemaDefinitions?.[0],updatesToUiSchema}
+      select: (data) => {
+        const uniqueFields = data?.SchemaDefinitions?.[0]?.definition?.["x-unique"];
+        const updatesToUiSchema = {};
+        uniqueFields.forEach((field) => (updatesToUiSchema[field] = { "ui:readonly": true }));
+        return { schema: data?.SchemaDefinitions?.[0], updatesToUiSchema };
       },
     },
-    changeQueryName:"schema"
+    changeQueryName: "schema",
   };
 
   const closeToast = () => {
     setTimeout(() => {
-      setShowToast(null)
+      setShowToast(null);
     }, 5000);
-  }
+  };
 
-  const gotoView = () => { 
+  const gotoView = () => {
     setTimeout(() => {
-      setRenderLoader(true)
-      history.push(`/${window?.contextPath}/employee/workbench/mdms-view?moduleName=${moduleName}&masterName=${masterName}&uniqueIdentifier=${uniqueIdentifier}`)
+      setRenderLoader(true);
+      history.goBack();
     }, 2000);
-  }
+  };
 
   const { isLoading, data, isFetching } = Digit.Hooks.useCustomAPIHook(reqCriteria);
-  const { isLoading:isLoadingSchema,data: schemaData,isFetching: isFetchingSchema,...rest } = Digit.Hooks.useCustomAPIHook(reqCriteriaSchema);
-  
+  const { isLoading: isLoadingSchema, data: schemaData, isFetching: isFetchingSchema, ...rest } = Digit.Hooks.useCustomAPIHook(reqCriteriaSchema);
 
   const reqCriteriaUpdate = {
-    url:  Digit.Utils.workbench.getMDMSActionURL(moduleName,masterName,"update"),
+    url: Digit.Utils.workbench.getMDMSActionURL(moduleName, masterName, "update"),
     params: {},
-    body: {
-      
-    },
+    body: {},
     config: {
       enabled: true,
     },
@@ -82,34 +79,31 @@ const MDMSEdit = ({...props}) => {
   const mutation = Digit.Hooks.useCustomAPIMutationHook(reqCriteriaUpdate);
 
   const handleUpdate = async (formData) => {
-
     const onSuccess = (resp) => {
-      
       setShowToast({
-        label:`${t("WBH_SUCCESS_UPD_MDMS_MSG")} ${resp?.mdms?.[0]?.id}`
+        label: `${t("WBH_SUCCESS_UPD_MDMS_MSG")} ${resp?.mdms?.[0]?.id}`,
       });
       // closeToast()
-      gotoView()
+      gotoView();
     };
 
     const onError = (resp) => {
       setShowToast({
-        label:`${t("WBH_ERROR_MDMS_DATA")} ${t(resp?.response?.data?.Errors?.[0]?.code)}`,
-        isError:true
+        label: `${t("WBH_ERROR_MDMS_DATA")} ${t(resp?.response?.data?.Errors?.[0]?.code)}`,
+        isError: true,
       });
-      
-      closeToast()
-    };
 
+      closeToast();
+    };
 
     mutation.mutate(
       {
-        url:reqCriteriaUpdate?.url,
+        url: reqCriteriaUpdate?.url,
         params: {},
         body: {
-          Mdms:{
+          Mdms: {
             ...data,
-            data:formData
+            data: formData,
           },
         },
       },
@@ -118,17 +112,16 @@ const MDMSEdit = ({...props}) => {
         onSuccess,
       }
     );
+  };
 
-  }
+  if (isLoading || isLoadingSchema || renderLoader) return <Loader />;
 
-  if(isLoading || isLoadingSchema || renderLoader ) return <Loader />
-  
   return (
     <React.Fragment>
-      <MDMSAdd defaultFormData = {data?.data} screenType={"edit"} onSubmitEditAction={handleUpdate} updatesToUISchema ={schemaData?.updatesToUiSchema} />
-      {showToast && <Toast label={t(showToast.label)} error={showToast?.isError} onClose={()=>setShowToast(null)} ></Toast>}
+      <MDMSAdd defaultFormData={data?.data} screenType={"edit"} onSubmitEditAction={handleUpdate} updatesToUISchema={schemaData?.updatesToUiSchema} />
+      {showToast && <Toast label={t(showToast.label)} error={showToast?.isError} onClose={() => setShowToast(null)}></Toast>}
     </React.Fragment>
-  )
-}
+  );
+};
 
-export default MDMSEdit
+export default MDMSEdit;


### PR DESCRIPTION
In workbench UI, when we click on any master data then it first goes to view screen and we want to edit it then we go to edit screen. Now after updating it again go to view screen.

Problem-> on updating master data it goes to view screen like this-> (history.push(view-screen)). And then if we want to go back then we will first go to edit screen then view screen then summary screen of rate master. 

Change-> Line 64 ( Instead of pushing an extra url in stack, I pop it instead to get view screen.)

