### PR TITLE
BUGFIX/HCMPRE-2345:PlanInbox Assign to All counts

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/pages/employee/PlanInbox.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/pages/employee/PlanInbox.js
@@ -473,7 +473,6 @@ const PlanInbox = () => {
   useEffect(() => {
     if (planWithCensusCount) {
       setAssignedToMeCount(planWithCensusCount?.TotalCount);
-      setAssignedToAllCount(planWithCensusCount?.TotalCount);
     }
   }, [planWithCensusCount]);
 


### PR DESCRIPTION
BUGFIX/HCMPRE-2345:PlanInbox Assign to All count fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the employee inbox display so that the total count of assigned plans now retains its previous value rather than auto-updating from incoming data, ensuring a more consistent view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->