### PR TITLE
BUGFIX/HCMPRE-2378:Microplan Search Screen download button and Preview for DataManagemens

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/example/src/UICustomizations.js
+++ b/health/micro-ui/web/micro-ui-internals/example/src/UICustomizations.js
@@ -801,6 +801,7 @@ export const UICustomizations = {
             // TODO : Replace dummy file id with real file id when API is ready
             const dummyFile = "c22a7676-d5d7-49b6-bcdb-83e9519f58df"
             const microplanFileId = row?.campaignDetails?.additionalDetails?.microplanFileId || dummyFile;
+            const EstimationsfileId = row?.files.find((item) => item.templateIdentifier === "Estimations")?.filestoreId;
             let options = [];
   
             if (row?.status == "DRAFT") {
@@ -810,9 +811,8 @@ export const UICustomizations = {
             }
   
             const handleDownload = () => {
-              const files = row?.files;
-              const file = files.find((item) => item.templateIdentifier === "Population");
-              const fileId = file?.filestoreId;
+              
+              const fileId = row?.files.find((item) => item.templateIdentifier === "Estimations")?.filestoreId;
               if (!fileId) {
                     console.error("Population template file not found");
                     return;
@@ -842,7 +842,7 @@ export const UICustomizations = {
               <div>
                 {microplanFileId && row?.status == "RESOURCE_ESTIMATIONS_APPROVED" ? (
                   <div>
-                    <ButtonNew style={{ width: "20rem" }} icon="DownloadIcon" onClick={handleDownload} label={t("WBH_DOWNLOAD_MICROPLAN")} title={t("WBH_DOWNLOAD_MICROPLAN")}  />
+                    <ButtonNew style={{ width: "20rem" }} icon="DownloadIcon" onClick={handleDownload} label={t("WBH_DOWNLOAD_MICROPLAN")} title={t("WBH_DOWNLOAD_MICROPLAN")} isDisabled={!EstimationsfileId} />
                   </div>
                 ) : (
                   <div className={"action-button-open-microplan"}>

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/DataMgmtComponent.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/DataMgmtComponent.js
@@ -64,10 +64,7 @@ export const DataMgmtComponent = ({ customProps, setupCompleted }) => {
                                     });
                                 }} // Passing the download function
                                 status="completed"
-
-
-
-
+                                rowDetails={item}
                             />
                         )
 
@@ -114,6 +111,7 @@ export const DataMgmtComponent = ({ customProps, setupCompleted }) => {
                                     });
                                 }} // Passing the download function
                                 status="completed"
+                                rowDetails={item}
 
                             />
                         )

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/FileComponent.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/FileComponent.js
@@ -52,7 +52,7 @@ const FileComponent = ({ title, fileName, status, auditDetails, editHandler, del
                     className="dm-uploaded-file-container-sub"
                     style={{ marginLeft: "-1rem" }}
                 >
-                    <div onClick={async () => await handleFilePreview(rowDetails?.fileStoreId)}>
+                    <div onClick={async () => await handleFilePreview(rowDetails?.fileStoreId || rowDetails?.filestoreId)}>
                         <XlsxFile styles={{ width: "6rem", height: "6rem" }} />
                     </div>
                     <div style={{ marginLeft: "0.5rem", marginTop: "0.5rem" }}>{fileName}</div>

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/configs/UICustomizations.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/configs/UICustomizations.js
@@ -83,6 +83,7 @@ export const UICustomizations = {
           // TODO : Replace dummy file id with real file id when API is ready
           const dummyFile = "c22a7676-d5d7-49b6-bcdb-83e9519f58df"
           const microplanFileId = row?.campaignDetails?.additionalDetails?.microplanFileId || dummyFile;
+          const EstimationsfileId = row?.files.find((item) => item.templateIdentifier === "Estimations")?.filestoreId;
           let options = [];
 
           if (row?.status == "DRAFT") {
@@ -92,9 +93,7 @@ export const UICustomizations = {
           }
 
           const handleDownload = () => {
-            const files = row?.files;
-            const file = files.find((item) => item.templateIdentifier === "Population");
-            const fileId = file?.filestoreId;
+            const fileId = row?.files.find((item) => item.templateIdentifier === "Estimations")?.filestoreId;
             if (!fileId) {
                   console.error("Population template file not found");
                   return;
@@ -124,7 +123,7 @@ export const UICustomizations = {
             <div>
               {microplanFileId && row?.status == "RESOURCE_ESTIMATIONS_APPROVED" ? (
                 <div>
-                  <ButtonNew style={{ width: "20rem" }} icon="DownloadIcon" onClick={handleDownload} label={t("WBH_DOWNLOAD_MICROPLAN")} title={t("WBH_DOWNLOAD_MICROPLAN")}  />
+                  <ButtonNew style={{ width: "20rem" }} icon="DownloadIcon" onClick={handleDownload} label={t("WBH_DOWNLOAD_MICROPLAN")} title={t("WBH_DOWNLOAD_MICROPLAN")} isDisabled={!EstimationsfileId}  />
                 </div>
               ) : (
                 <div className={"action-button-open-microplan"}>


### PR DESCRIPTION
BUGFIX/HCMPRE-2378:Microplan Search Screen download button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The microplan download button now only activates when the "Estimations" file is available, enhancing user control over download actions.
  - Additional file details are now passed to the FileComponent, improving the information displayed for each file or facility.

- **Bug Fixes**
  - The file preview functionality has been improved to handle cases where the fileStoreId might not be available, ensuring a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->