### PR TITLE
BUGFIX/HCMPRE-2555 : Fixed extra link,disable Single round and multir…

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CampaignCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CampaignCard.js
@@ -31,12 +31,12 @@ const CampaignCard = () => {
     {
       label: t("ACTION_TEST_SETUP_CAMPAIGN"),
       link: `/${window?.contextPath}/employee/campaign/setup-campaign`,
-      roles: ROLES.CAMPAIGN_MANAGER_ONLY,
+      roles: ROLES.BOUNDARY_MANAGER,
     },
     {
       label: t("ACTION_TEST_MY_CAMPAIGN"),
       link: `/${window?.contextPath}/employee/campaign/my-campaign`,
-      roles: ROLES.CAMPAIGN_MANAGER,
+      roles: ROLES.BOUNDARY_MANAGER,
       // count: isLoading?"-":data
     },
     {
@@ -48,7 +48,7 @@ const CampaignCard = () => {
     {
       label: t("ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN"),
       link: `/${window?.contextPath}/employee/campaign/setup-from-microplan?status=${microplanStatus}`,
-      roles: ROLES.MICROPLAN_INTEGRATOR,
+      roles: ROLES.BOUNDARY_MANAGER,
     },
     {
       label: t("NATIONAL_DASHBOARD"),

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CloneCampaignWrapper.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CloneCampaignWrapper.js
@@ -64,10 +64,36 @@ const CloneCampaignWrapper = (props) => {
   };
 
   const onNextClick = async () => {
-    if (name.length > 30) {
+    let hasError = false;
+
+    // Name validation
+    if (!name?.trim()) {
+      setNameError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
+      hasError = true;
+    } else if (name.length > 30) {
       setNameError({ message: "CAMPAIGN_NAME_GREATER" });
-      return;
+      hasError = true;
+    } else {
+      setNameError(null);
     }
+
+    // Start date validation
+    if (!startDate) {
+      setStartError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
+      hasError = true;
+    } else {
+      setStartError(null);
+    }
+
+    // End date validation
+    if (!endDate) {
+      setEndError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
+      hasError = true;
+    } else {
+      setEndError(null);
+    }
+
+    if (hasError) return;
     setIsValidatingName(true);
     let temp = await fetchValidCampaignName(tenantId, name);
     if (temp.length != 0) {
@@ -76,20 +102,6 @@ const CloneCampaignWrapper = (props) => {
       return;
     }
     setIsValidatingName(false);
-    if (!name?.trim()) {
-      setNameError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
-      return;
-    }
-
-    if (!startDate) {
-      setStartError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
-      return;
-    }
-
-    if (!endDate) {
-      setEndError({ message: "CAMPAIGN_FIELD_ERROR_MANDATORY" });
-      return;
-    }
 
     setShowProgress(true);
     // setError(null);
@@ -199,7 +211,16 @@ const CloneCampaignWrapper = (props) => {
           </div>
         )}
       </PopUp>
-      {toast && <Toast error={toast.key} isDleteBtn="true" label={t(toast.label)} onClose={handleToastClose} type={toast.type} />}
+      {toast && (
+        <Toast
+          style={{ zIndex: 10001 }}
+          error={toast.key}
+          isDleteBtn="true"
+          label={t(toast.label)}
+          onClose={handleToastClose}
+          type={toast?.key === "error" ? "error" : toast?.key === "info" ? "info" : toast?.key === "warning" ? "warning" : "success"}
+        />
+      )}
     </>
   );
 };

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CreateCampaignComponents.js/CycleSelection.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CreateCampaignComponents.js/CycleSelection.js
@@ -11,17 +11,15 @@ const CycleSelection = ({ onSelect, formData, ...props }) => {
     { code: "HCM_MULTI_ROUND", name: t("HCM_MULTI_ROUND") },
   ];
 
-  useEffect(() => {
-  if (formData?.CycleSelection) {
-    setSelectedOption(formData.CycleSelection);
-  } else if (formData?.CampaignType?.code === "DEFAULT") {
-    setSelectedOption(null);
-  } else if (formData?.CampaignType?.cycles?.length > 1) {
+useEffect(()=>{
+  if(formData?.CampaignType?.cycles?.length > 1){
     setSelectedOption("HCM_MULTI_ROUND");
-  } else {
-    setSelectedOption("HCM_SINGLE_ROUND");
   }
-}, [formData?.CampaignType?.code, formData?.CycleSelection]);
+  else{
+     setSelectedOption("HCM_SINGLE_ROUND");
+  }
+
+},[formData?.CampaignType?.code])
 
   useEffect(() =>{
     onSelect("CycleSelection", selectedOption);
@@ -36,7 +34,7 @@ const CycleSelection = ({ onSelect, formData, ...props }) => {
           onSelect={(selected) => {
             setSelectedOption(selected.code);
           }}
-          disabled = {props?.config?.customProps?.disabled}
+          disabled = {true}
           options={options}
           optionsKey="name"
           selectedOption={options.find((opt) => opt.code === selectedOption)}

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
@@ -46,7 +46,15 @@ const getTagElements = (rowData) => {
       stroke: true,
     };
   }
-  if (rowData?.deliveryRules?.[0]?.cycles?.length > 1) {
+  if (rowData?.deliveryRules?.[0]?.cycles?.length == 1) {
+    tags.type = {
+      label: "SINGLEROUND_CAMPAIGN",
+      showIcon: false,
+      type: "warning",
+      stroke: true,
+    };
+  }
+  else if (rowData?.deliveryRules?.[0]?.cycles?.length > 1) {
     tags.type = {
       label: "MULTIROUND_CAMPAIGN",
       showIcon: false,

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -223,13 +223,15 @@ const CampaignDetails = () => {
         </div>
         <div style={{ display: "flex" }}>
           <Tag label={t(campaignData?.projectType)} showIcon={false} className={"campaign-view-tag"} type={"warning"} stroke={true}></Tag>
-          <Tag
-            label={campaignData?.deliveryRules?.[0]?.cycles?.length > 1 ? t("HCM_MULTIROUND") : t("HCM_SINGLE_ROUND")}
-            showIcon={false}
-            className={"campaign-view-tag"}
-            type={"monochrome"}
-            stroke={true}
-          ></Tag>
+          {campaignData?.deliveryRules?.[0]?.cycles?.length >= 1 && (
+            <Tag
+              label={campaignData?.deliveryRules?.[0]?.cycles?.length > 1 ? t("HCM_MULTIROUND") : t("HCM_SINGLE_ROUND")}
+              showIcon={false}
+              className={"campaign-view-tag"}
+              type={"monochrome"}
+              stroke={true}
+            />
+          )}
         </div>
       </div>
       <div style={{ display: "flex", gap: "1rem" }}>

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -60,7 +60,6 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
     },
   });
 
-
   const transformDraftDataToFormData = (draftData) => {
     const restructureFormData = {
       ...draftData,
@@ -225,7 +224,9 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
                   `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${result?.CampaignDetails?.campaignNumber}&tenantId=${result?.CampaignDetails?.tenantId}&draft=${isDraft}`
                 );
               } else {
-                history.push(`/${window.contextPath}/employee/campaign/view-details?campaignNumber=${result?.CampaignDetails?.campaignNumber}&tenantId=${result?.CampaignDetails?.tenantId}`);
+                history.push(
+                  `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${result?.CampaignDetails?.campaignNumber}&tenantId=${result?.CampaignDetails?.tenantId}`
+                );
               }
               setLoader(false);
             }, 2000);
@@ -285,6 +286,7 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
       />
       {showToast && (
         <Toast
+          style={{ zIndex: 10001 }}
           type={showToast?.key === "error" ? "error" : showToast?.key === "info" ? "info" : showToast?.key === "warning" ? "warning" : "success"}
           label={t(showToast?.label)}
           transitionTime={showToast.transitionTime}

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -953,6 +953,19 @@ const SetupCampaign = ({ hierarchyType, hierarchyData }) => {
       setShouldUpdate(false);
       setCurrentKey(currentKey - 1);
     }
+    if (isSubmit) {
+      if (currentKey == 5 || currentKey == 7 || currentKey == 10) {
+        if (isDraft === "true") {
+          history.push(
+            `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${campaignNumber}&tenantId=${tenantId}&draft=${isDraft}`
+          );
+        } 
+        else {
+          history.push(`/${window.contextPath}/employee/campaign/view-details?campaignNumber=${campaignNumber}&tenantId=${tenantId}`);
+        }
+      }
+      return;
+    }
   };
 
   const [filteredConfig, setFilteredConfig] = useState(filterCampaignConfig(campaignConfig, currentKey));

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/OldCampaignCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/OldCampaignCard.js
@@ -23,12 +23,12 @@ const CampaignCard = () => {
     {
       label: t("ACTION_TEST_SETUP_CAMPAIGN"),
       link: `/workbench-ui/employee/campaign/setup-campaign`,
-      roles: ROLES.CAMPAIGN_MANAGER_ONLY,
+      roles: ROLES.BOUNDARY_MANAGER,
     },
     {
       label: t("ACTION_TEST_MY_CAMPAIGN"),
       link: `/workbench-ui/employee/campaign/my-campaign`,
-      roles: ROLES.CAMPAIGN_MANAGER,
+      roles: ROLES.BOUNDARY_MANAGER,
       // count: isLoading?"-":data
     },
     {
@@ -40,7 +40,7 @@ const CampaignCard = () => {
     {
       label: t("ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN"),
       link: `/${window?.contextPath}/employee/campaign/setup-from-microplan?userId=${userId}&status=${microplanStatus}`,
-      roles: ROLES.CAMPAIGN_MANAGER,
+      roles: ROLES.BOUNDARY_MANAGER,
     },
     {
       label: t("NATIONAL_DASHBOARD"),
@@ -99,7 +99,7 @@ const CampaignCard = () => {
     {
       label: t("ACTION_TEST_APP_CONFIGURATION_3.0"),
       link: `/workbench-ui/employee/campaign/app-configuration-redesign?variant=app&masterName=SimplifiedAppConfigTwo&fieldType=AppFieldTypeOne&prefix=APPTWO&localeModule=APPTWO&formId=default`,
-      roles: ROLES.CAMPAIGN_MANAGER,
+      roles: ROLES.BOUNDARY_MANAGER,
       // count: isLoading?"-":data
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a distinct tag for single-round campaigns, making it easier to differentiate between single-round and multi-round campaigns in campaign listings and details.

- **Improvements**
	- Updated campaign-related links to require the boundary manager role for access.
	- Enhanced campaign creation and cloning forms with improved validation and clearer error messaging.
	- Adjusted navigation behavior during campaign setup to streamline user redirection at specific steps.
	- Improved visual stacking of toast notifications for better visibility.
	- Disabled cycle selection options to prevent unintended changes.

- **Bug Fixes**
	- Fixed conditional rendering of campaign type tags to display only when relevant data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->