### PR TITLE
HCMPRE-2256:: fix for employee search

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-hrms/src/services/service.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-hrms/src/services/service.js
@@ -13,7 +13,7 @@ import HrmsService from "./hrms/HRMSService";
  */
 export const checkIfUserExistWithPhoneNumber = async (data, tenantId) => {
   try {
-    debugger
+    
     //  if (data?.SelectEmployeePhoneNumber && data?.SelectEmployeePhoneNumber?.trim().length > 0) {
     const result = await HrmsService.search(tenantId, null, { phone: data?.SelectEmployeePhoneNumber });
 
@@ -251,7 +251,7 @@ export const editDefaultUserValue = (data, tenantId) => {
     fromDate: null,
     toDate: null,
   };
-debugger
+
   return defaultValues;
 };
 

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-hrms/src/services/service.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-hrms/src/services/service.js
@@ -2,6 +2,7 @@ import { HRMS_CONSTANTS } from "../constants/constants";
 const hierarchyType = window?.globalConfigs?.getConfig("HIERARCHY_TYPE") || "HIERARCHYTEST";
 import { convertEpochToDate } from "../utils/utlis";
 import employeeDetailsFetch from "./FetchEmployeeDetails";
+import HrmsService from "./hrms/HRMSService";
 
 /**
  * Checks if a user exists with the given phone number.
@@ -12,8 +13,9 @@ import employeeDetailsFetch from "./FetchEmployeeDetails";
  */
 export const checkIfUserExistWithPhoneNumber = async (data, tenantId) => {
   try {
+    debugger
     //  if (data?.SelectEmployeePhoneNumber && data?.SelectEmployeePhoneNumber?.trim().length > 0) {
-    const result = await Digit.HRMSService.search(tenantId, null, { phone: data?.SelectEmployeePhoneNumber });
+    const result = await HrmsService.search(tenantId, null, { phone: data?.SelectEmployeePhoneNumber });
 
     if (result?.Employees?.length > 0) {
       return true; // User exists, return false
@@ -38,7 +40,7 @@ export const checkIfUserExistWithPhoneNumber = async (data, tenantId) => {
 export const checkIfUserExist = async (data, tenantId) => {
   try {
     if (data?.SelectEmployeeId && data?.SelectEmployeeId?.trim().length > 0) {
-      const result = await Digit.HRMSService.search(tenantId, null, { codes: data?.SelectEmployeeId });
+      const result = await HrmsService.search(tenantId, null, { codes: data?.SelectEmployeeId })
 
       if (result?.Employees?.length > 0) {
         return true; // User exists, return false
@@ -249,7 +251,7 @@ export const editDefaultUserValue = (data, tenantId) => {
     fromDate: null,
     toDate: null,
   };
-
+debugger
   return defaultValues;
 };
 


### PR DESCRIPTION
Root Cause Analysis (RCA):
While creating a new user, the application triggers an employee search API call to check for existing users with the same name or phone number. By default, this API was configured to point to the Digit HRMS service from the core module, which uses the egov-hrms context path. As a result, the request was incorrectly directed to the wrong HRMS service.

Fix:
We updated the configuration to point the API to our custom HRMS service, which uses the health-hrms context path. This change ensured that the API request is routed to the correct service, thereby resolving the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Internal service usage updated for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->