### PR TITLE
BUGFIX/GIT-2692:: Added margin for Custom Image Component in App Preview

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/DynamicImageComponent.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/DynamicImageComponent.js
@@ -4,7 +4,8 @@ import PropTypes from "prop-types";
 export const DynamicImageComponent = ({ type, appType }) => {
   return (
     <img
-      src={`https://egov-dev-assets.s3.ap-south-1.amazonaws.com/hcm/${type}/${appType}.svg`} // TODO @Nabeel @jagan @bhavya scan through the app we should have s3 urls added in app directly 
+      src={`https://egov-dev-assets.s3.ap-south-1.amazonaws.com/hcm/${type}/${appType}.svg`}
+      style={{marginTop: "0.5rem", marginBottom: "0.5rem"}} // TODO @Nabeel @jagan @bhavya scan through the app we should have s3 urls added in app directly 
       className="dynamic-image-component"
       alt={`Unsupported field type: ${type}`}
     />

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/DynamicSVGComponent.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/DynamicSVGComponent.js
@@ -24,7 +24,7 @@ const DynamicSVG = ({ type,appType, data }) => {
   }, [url, data]);
 
   return (
-    <div
+    <div style={{ marginTop: "0.5rem", marginBottom: "0.5rem" }} // TODO @Nabeel @jagan @bhavya scan through the app we should have s3 urls added in app directly
       dangerouslySetInnerHTML={{ __html: svgContent }}
     />
   );

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/utils/template_components/RegistrationComponents.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/utils/template_components/RegistrationComponents.js
@@ -524,14 +524,6 @@ const DetailsCardSection = ({ field, t }) => {
 
       <div
         className="no-x-scroll"
-        style={{
-          overflowY: 'auto',
-          overflowX: 'hidden',
-          scrollbarWidth: 'thin',       // Firefox
-          msOverflowStyle: 'auto',      // Edge/IE
-          maxHeight: '300px',
-          whiteSpace: 'nowrap'
-        }}
       >
         <h1 style={{ fontWeight: "bold", marginBottom: "0.5rem", fontSize: "25px" }}>
           {heading}


### PR DESCRIPTION

### [Bugfix PR](https://github.com/orgs/egovernments/projects/16/views/3?pane=issue&itemId=117684335&issue=egovernments%7CDIGIT-Frontend%7C2692)

#### Bugfix Request

**GITHUB Issue**  
[Issue 2692](https://github.com/orgs/egovernments/projects/16/views/3?pane=issue&itemId=117684335&issue=egovernments%7CDIGIT-Frontend%7C2692)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added consistent vertical spacing to images and SVGs in campaign manager components for improved layout appearance.
  * Removed scrollbars and size constraints from detail card sections to enhance content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->