### PR TITLE
BUGFIX/HCMPRE-2875 : Filter Removal for level-2 Distict wise data Table

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
@@ -512,9 +512,14 @@ const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setC
   };
 
   const removeFilter = (id) => {
-    setFilterStack(prev => prev.filter((_, idx) => idx < id));
-    setChartKey(filterStack?.[-1]?.id || data?.id);
+    setFilterStack(prev => {
+      const newStack = prev.filter((_, idx) => idx < id);
+      const lastId = newStack.length > 0 ? newStack[newStack.length - 1].id : data?.id;
+      setChartKey(lastId);
+      return newStack;
+    });
   };
+  
 
   
 

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
@@ -141,7 +141,11 @@ const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setC
     moduleLevel: value?.moduleLevel,
     aggregationFactors: null,
   };
-  const { isLoading, data: response } = Digit.Hooks.DSS.useGetChartV2(aggregationRequestDto2);
+  const { isLoading, data: response, refetch } = Digit.Hooks.DSS.useGetChartV2(aggregationRequestDto2);
+
+  useEffect(() => {
+    refetch();
+  }, [filterStack]);
 
 
   useEffect(() => {
@@ -217,7 +221,7 @@ const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setC
           return acc;
         }, {});
       });
-  }, [response, lastYearResponse, onSearch]);
+  }, [response, lastYearResponse, onSearch, filterStack]);
 
   useEffect(() => {
     if (tableData) {
@@ -506,6 +510,13 @@ const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setC
     setFilterStack(nextState);
     setChartKey(nextState[nextState?.length - 1]?.id);
   };
+
+  const removeFilter = (id) => {
+    setFilterStack(prev => prev.filter((_, idx) => idx !== id));
+    setChartKey(filterStack?.[id - 1]?.id);
+  };
+
+  
 
   if (isLoading || isRequestLoading) {
     return <Loader className={"digit-center-loader"} />;

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
@@ -42,7 +42,7 @@ const calculateFSTPCapacityUtilization = (value, totalCapacity, numberOfDays = 1
 const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setChartDenomination }) => {
   const { id } = data;
   const [chartKey, setChartKey] = useState(id);
-  const [filterStack, setFilterStack] = useState([{ id: chartKey, hierarchyLevel:2 }]);
+  const [filterStack, setFilterStack] = useState([{ id: chartKey}]);
   const { t } = useTranslation();
   const { value, setValue, ulbTenants, fstpMdmsData } = useContext(FilterContext);
   const tenantId = Digit?.ULBService?.getCurrentTenantId();

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/CustomTable.js
@@ -42,7 +42,7 @@ const calculateFSTPCapacityUtilization = (value, totalCapacity, numberOfDays = 1
 const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setChartDenomination }) => {
   const { id } = data;
   const [chartKey, setChartKey] = useState(id);
-  const [filterStack, setFilterStack] = useState([{ id: chartKey }]);
+  const [filterStack, setFilterStack] = useState([{ id: chartKey, hierarchyLevel:2 }]);
   const { t } = useTranslation();
   const { value, setValue, ulbTenants, fstpMdmsData } = useContext(FilterContext);
   const tenantId = Digit?.ULBService?.getCurrentTenantId();
@@ -512,8 +512,8 @@ const CustomTable = ({ data = {}, onSearch = { searchQuery }, setChartData, setC
   };
 
   const removeFilter = (id) => {
-    setFilterStack(prev => prev.filter((_, idx) => idx !== id));
-    setChartKey(filterStack?.[id - 1]?.id);
+    setFilterStack(prev => prev.filter((_, idx) => idx < id));
+    setChartKey(filterStack?.[-1]?.id || data?.id);
   };
 
   

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/hooks/useGetChartV2.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/hooks/useGetChartV2.js
@@ -27,9 +27,9 @@ const useGetChartV2 = (aggregationRequestDto) => {
     [aggregationRequestDto, tenantId, authToken, defaultSelect]
   );
 
-  const { data, isLoading } = Digit.Hooks.useCustomAPIHook(reqCriteria);
+  const { data, isLoading, refetch } = Digit.Hooks.useCustomAPIHook(reqCriteria);
 
-  return { data, isLoading };
+  return { data, isLoading, refetch };
 };
 
 export default useGetChartV2;


### PR DESCRIPTION
Filter Removal for level-2 Distict wise data Table 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart and table data now automatically refresh when filters are updated.
  * Users can remove filters directly from the UI, with the data updating accordingly.

* **Improvements**
  * Manual data refresh is now possible for charts, ensuring up-to-date information after filter changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->