### PR TITLE
BUGFIX/HCMPRE-1817 : Fixed checklist update, search cache

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CampaignCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/CampaignCard.js
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import React, { Fragment } from "react";
+import React, { Fragment , useEffect } from "react";
 import { EmployeeModuleCard } from "@egovernments/digit-ui-react-components";
 
 const ROLES = {
@@ -26,6 +26,10 @@ const CampaignCard = () => {
 
   const { t } = useTranslation();
   const microplanStatus = "RESOURCE_ESTIMATIONS_APPROVED";
+
+   useEffect(() => {
+      sessionStorage.removeItem("HCM_SELECTED_TAB_INDEX");
+    }, []);
 
   let links = [
     {

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
@@ -255,7 +255,10 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
   };
   const durationDays = calculateDurationInDays(rowData?.startDate, rowData?.endDate);
   const duration = durationDays !== "NA" ? `${durationDays} ${t("Days")}` : "NA";
-  const noOfCycles = rowData?.additionalDetails?.cycleData?.cycleConfgureDate?.cycle || "NA";
+  const noOfCycles = rowData?.additionalDetails?.cycleData?.cycleConfgureDate?.cycle != null
+  ? rowData.additionalDetails.cycleData.cycleConfgureDate.cycle
+  : (rowData?.deliveryRules?.[0]?.cycles?.length != null ? rowData.deliveryRules[0].cycles.length : "NA");
+  // const noOfCycles = rowData?.additionalDetails?.cycleData?.cycleConfgureDate?.cycle ? rowData?.additionalDetails?.cycleData?.cycleConfgureDate?.cycle : rowData?.deliveryRules?.[0]?.cycles?.length || "NA";
   const resources = rowData?.deliveryRules?.flatMap((rule) => rule.resources?.map((res) => t(res.name))).join(", ") || "NA";
   const [showErrorPopUp, setShowErrorPopUp] = useState(false);
   const [showCreatingPopUp, setShowCreatingPopUp] = useState(false);
@@ -396,7 +399,7 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
           heading={t("ES_CAMPAIGN_FAILED_ERROR")}
           children={[
             <div>
-              <CardText style={{ margin: 0 }}>{rowData?.additionalDetails?.error}</CardText>
+              <CardText style={{ margin: 0 }}>{t(rowData?.additionalDetails?.error)}</CardText>
             </div>,
           ]}
           onOverlayClick={() => {

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/configs/checklistSearchConfig.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/configs/checklistSearchConfig.js
@@ -1,6 +1,4 @@
-
-  
-  const tenantId = Digit?.ULBService?.getCurrentTenantId();
+  const tenantId = Digit?.ULBService?.getCurrentTenantId() || "mz";
   const mdms_context_path = window?.globalConfigs?.getConfig("MDMS_V2_CONTEXT_PATH") || "mdms-v2";
   export const checklistSearchConfig = [
     {

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/UpdateChecklist.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/campaign-manager/src/pages/employee/UpdateChecklist.js
@@ -580,7 +580,7 @@ const UpdateChecklist = () => {
         // { label: "CHECKLIST_NAME", value: name}            
     ];
 
-    if (isLoading) {
+    if (isLoading || !searchLocalisationData || searchLocalisationData?.length === 0) {
         return <Loader page={true} variant={"PageLoader"}/>;
     }
     return (

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/OldCampaignCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/microplan/src/components/OldCampaignCard.js
@@ -1,5 +1,5 @@
 import { EmployeeModuleCard, SVG } from "@egovernments/digit-ui-react-components";
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 const ROLES = {
@@ -17,8 +17,12 @@ const CampaignCard = () => {
 
   const { t } = useTranslation();
   const userId = Digit.UserService.getUser().info.uuid;
-  const microplanStatus =  "RESOURCE_ESTIMATIONS_APPROVED"
- 
+  const microplanStatus = "RESOURCE_ESTIMATIONS_APPROVED";
+
+  useEffect(() => {
+    sessionStorage.removeItem("HCM_SELECTED_TAB_INDEX");
+  }, []);
+
   let links = [
     {
       label: t("ACTION_TEST_CREATE_CAMPAIGN"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logic for displaying the number of cycles in campaign cards, ensuring accurate values even when some data is missing.
  * Error messages in campaign row cards are now properly localized.
  * The loader in the Update Checklist page now appears when localization data is missing or empty, preventing premature rendering.

* **Chores**
  * Session storage is now cleared for selected tab index when viewing campaign cards, ensuring a consistent user experience.
  * Default value added for tenant ID to prevent issues when tenant information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->