### PR TITLE
breadcum issue fixed in pgr service

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/index.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/index.js
@@ -54,7 +54,7 @@ const EmployeeApp = ({ path, stateCode, userType, tenants }) => {
               {
                 internalLink: `/${window?.contextPath}/employee/pgr/inbox-v2`,
                 content: t("PGR_INBOX"),
-                show: location.pathname.includes("inbox"),
+                show: location.pathname.includes("inbox") || location.pathname.includes("complaint-details"),
               },
               {
                 internalLink: `/${window?.contextPath}/employee/pgr/complaint-details`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Inbox breadcrumb was missing on complaint detail pages. The breadcrumb now appears on both the Inbox and complaint details, offering consistent context and a quicker path back to the Inbox during case review. No other navigation behavior is affected. Improves overall navigation clarity for employees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->