### PR TITLE
BUGFIX/HCMPRE-1145: Adding roles to dss dashboard Card

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/DSSCard.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-dss/src/components/DSSCard.js
@@ -6,7 +6,7 @@ const DSSCard = () => {
   const { t } = useTranslation();
 
   const ROLES = {
-    HEALTH_DSS: ["NATIONAL_SUPERVISOR, DASHBOARD_VIEWER"],
+    HEALTH_DSS: ["NATIONAL_SUPERVISOR", "DASHBOARD_VIEWER"],
   };
 
   const generateLink = (labelKey, pathSuffix) => {


### PR DESCRIPTION
Adding roles to dss dashboard Card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The DSS Dashboard card is now role-gated and visible only to authorized users (NATIONAL_SUPERVISOR, DASHBOARD_VIEWER).
  * Users without the required roles will no longer see the DSS card in the interface.
  * For eligible users, the card behaves and functions exactly as before with no changes to navigation or interactions.
  * Reduces interface clutter for unauthorized users and strengthens access control for dashboard content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->