### PR TITLE
BUGFIX/GIT-3473:: Delivery rules fixes during update flow and refetching delivery rules

### DIFF
--- a/health/micro-ui/web/packages/modules/campaign-manager/src/components/DeliveryDetailsSummary.js
+++ b/health/micro-ui/web/packages/modules/campaign-manager/src/components/DeliveryDetailsSummary.js
@@ -111,8 +111,8 @@ function reverseDeliveryRemap(data, t) {
 
       // Handle "IN_BETWEEN" operator
       if (parts.length === 5 && (parts[1] === "<=" || parts[1] === "<") && (parts[3] === "<" || parts[3] === "<=")) {
-        const toValue = parts[0];
-        const fromValue = parts[4];
+        const fromValue = parts[0];
+        const toValue = parts[4];
         attributes.push({
           key: attributes.length + 1,
           operator: { code: operatorMapping["IN_BETWEEN"] },

--- a/health/micro-ui/web/packages/modules/campaign-manager/src/components/DetailsTable.js
+++ b/health/micro-ui/web/packages/modules/campaign-manager/src/components/DetailsTable.js
@@ -15,7 +15,7 @@ const DetailsTable = ({ className = "", columnsData, rowsData, summaryRows, card
       if (i?.operator?.code === "IN_BETWEEN") {
         return {
           ...i,
-          value: `${i?.toValue ? i?.toValue : "N/A"}  to ${i?.fromValue ? i?.fromValue : "N/A"}`,
+          value: `${i?.fromValue ? i?.fromValue : "N/A"}  to ${i?.toValue ? i?.toValue : "N/A"}`,
           operator: t(i?.operator?.code) || t(i?.operator),
       attribute: i?.attribute?.code ||  i?.attribute ? t(`CAMPAIGN_ATTRIBUTE_${i?.attribute?.code?.toUpperCase()}`) : "",
         };

--- a/health/micro-ui/web/packages/modules/campaign-manager/src/utils/setupCampaignHelpers.js
+++ b/health/micro-ui/web/packages/modules/campaign-manager/src/utils/setupCampaignHelpers.js
@@ -94,8 +94,8 @@ export const cycleDataRemap=(data)=> {
   
         // Handle "IN_BETWEEN" operator
         if (parts.length === 5 && (parts[1] === "<=" || parts[1] === "<") && (parts[3] === "<" || parts[3] === "<=")) {
-          const toValue = parts[0];
-          const fromValue = parts[4];
+          const fromValue = parts[0];
+          const toValue = parts[4];
           attributes.push({
             key: attributes.length + 1,
             operator: { code: operatorMapping["IN_BETWEEN"] },


### PR DESCRIPTION


#### BUGFIX-3473

**GIT ISSUE ID**  
[https://github.com/egovernments/DIGIT-Frontend/issues/3473](https://github.com/egovernments/DIGIT-Frontend/issues/3473)

**Module**  
Console

**Description**  
In the summary screen for delivery conditions, values for in between operators are coming opposite after adding and going for update immediately



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of range values in campaign conditions to ensure minimum and maximum values are displayed and processed in the correct sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->