### PR TITLE
BUGFIX/HCMPRE-3553 : checklist CTA button to use secondary variation after configured

### DIFF
--- a/health/micro-ui/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -258,6 +258,8 @@ const CampaignDetails = () => {
     },
     campaignName: campaignData?.campaignName,
     campaignType: campaignData?.projectType,
+    serviceDefinitionLimit: 1,
+    enabled: !!campaignData?.campaignName && !!campaignData?.projectType,
   });
 
   // Checking if any checklists are configured (have ServiceRequest in merged data)


### PR DESCRIPTION
BUGFIX/HCMPRE-3553 : checklist CTA button to use secondary variation after configured



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign-scoped service lookup with paginated retrieval and configurable limits; campaign-specific detection of checklist templates.
  * Campaign Details UI now reflects checklist presence by toggling button label and style (edit vs. create).

* **Bug Fixes**
  * More reliable checklist detection for the current tenant/campaign/type and improved control over when the lookup runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->