### PR TITLE
fix(docs): correct documentation links in README files (remove duplic…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run this project, you will need to add the following environment variables to
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 ## Support
 

--- a/health/micro-ui/README.md
+++ b/health/micro-ui/README.md
@@ -164,7 +164,7 @@ This README should provide clarity on setting up and running your project locall
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/health/micro-ui/web/micro-ui-internals/README.md
+++ b/health/micro-ui/web/micro-ui-internals/README.md
@@ -153,7 +153,7 @@ This README should provide clarity on setting up and running your project locall
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/micro-ui/README.md
+++ b/micro-ui/README.md
@@ -95,7 +95,7 @@ To run this project, you will need to add the following environment variables to
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/micro-ui/web/micro-ui-internals/README.md
+++ b/micro-ui/web/micro-ui-internals/README.md
@@ -96,7 +96,7 @@ To create your own globalConfig, copy and refer the below file.
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support


### PR DESCRIPTION
#### Feature/Bugfix Request

**JIRA ID**  
N/A

**Module**  
Documentation / README

**Description**  
Fix broken documentation links in several top-level README files. Each README contained a duplicated protocol prefix (`https://https://...`) which produced invalid URLs. This PR removes the extra `https://`.

**Change Summary**
- Replaced `https://https://core.digit.org/...` with `https://core.digit.org/...` in all affected README files
- No functional code changes

**Files Changed**
- `README.md`
- `micro-ui/README.md`
- `micro-ui/web/micro-ui-internals/README.md`
- `health/micro-ui/README.md`
- `health/micro-ui/web/micro-ui-internals/README.md`

**Testing Performed**
- Searched repo for `https://https://core.digit.org` to confirm occurrences
- Opened each README to verify link now points to `https://core.digit.org/...`
- Committed changes on branch `dev`

**How to Verify**
1. Open each file listed under *Files Changed* in GitHub or locally.
2. Confirm the Documentation link points to:
   `https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui`
3. Click the link in GitHub preview — it should open the documentation page.

**Migration / Rollback Notes**
- None required. Reverting the commit will restore previous co

Image for reference
<img width="1918" height="1029" alt="image" src="https://github.com/user-attachments/assets/85fdbd3b-5391-4616-8163-0ba85c164dcc" />
ntent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Fixed malformed documentation links in multiple README files that contained duplicate URL prefixes, ensuring proper access to the developer documentation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->