### PR TITLE
BUGFIX/HCMPRE-4455:: yarn build fix due to recent package upgrade

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/webpack.config.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const webpack = require("webpack");
 const CompressionPlugin = require("compression-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 // const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer"); // enable when needed
 
 // Environment-based configuration
@@ -34,6 +35,18 @@ module.exports = {
     sideEffects: false, // Enable tree-shaking
     concatenateModules: isProduction,
     minimize: isProduction,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          output: {
+            // Preserve webpackIgnore comments so downstream webpack builds
+            // honour them (e.g. @cyntler/react-doc-viewer's pdf.js Node polyfills)
+            comments: /^\**!|@preserve|@license|@cc_on|webpackIgnore/i,
+          },
+        },
+        extractComments: false,
+      }),
+    ],
     runtimeChunk: false, // Keep runtime in main bundle for library compatibility
     splitChunks: {
       chunks: "async", // Only split async chunks (for lazy loading)


### PR DESCRIPTION
**RCA:** @cyntler/react-doc-viewer (pdf.js internally) uses dynamic import() for Node.js polyfills (fs, http, url) with /*webpackIgnore: true*/ comments to skip them in browser builds. Our Terser minification   was stripping these magic comments from dist/main.js, so the Docker webpack build couldn't find the referenced chunk files (empty-GlqisfcO.js, index-B0Gk_P0t.js, etc.).


**Fix:** Configured TerserPlugin to preserve webpackIgnore comments during minification. The dynamic imports are Node.js-only (never execute in browser), so they're safely skipped by webpack when the comments   are intact.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced JavaScript minification in the build process with improved comment preservation during optimization to reduce bundle size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->