### PR TITLE
fix(docs): remove duplicated protocol prefix in documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run this project, you will need to add the following environment variables to
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 ## Support
 

--- a/health/micro-ui/README.md
+++ b/health/micro-ui/README.md
@@ -164,7 +164,7 @@ This README should provide clarity on setting up and running your project locall
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/health/micro-ui/web/micro-ui-internals/README.md
+++ b/health/micro-ui/web/micro-ui-internals/README.md
@@ -153,7 +153,7 @@ This README should provide clarity on setting up and running your project locall
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/micro-ui/README.md
+++ b/micro-ui/README.md
@@ -95,7 +95,7 @@ To run this project, you will need to add the following environment variables to
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support

--- a/micro-ui/web/micro-ui-internals/README.md
+++ b/micro-ui/web/micro-ui-internals/README.md
@@ -96,7 +96,7 @@ To create your own globalConfig, copy and refer the below file.
 
 ## Documentation
 
-[Documentation](https://https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
+[Documentation](https://core.digit.org/guides/developer-guide/ui-developer-guide/digit-ui)
 
 
 ## Support


### PR DESCRIPTION
Feature/Bugfix Request

JIRA ID
N/A

Module
Documentation / README

Description
This PR fixes broken documentation links caused by a duplicated https:// prefix in multiple README files.

The links were previously written as:
https://https://core.digit.org/...

They have been corrected to:
https://core.digit.org/...

This ensures that the Documentation links work correctly across all affected modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken documentation links across multiple README files by removing duplicate URL protocol prefixes, restoring access to developer guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->