### PR TITLE
BUGFIX/HCMPRE-8888 : Fix blank upload screen caused by customProps.type

### DIFF
--- a/health/micro-ui-react19/web/builds/console/public/index.html
+++ b/health/micro-ui-react19/web/builds/console/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-03/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.7/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.8/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/builds/core-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/core-ui/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-03/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.7/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.8/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-03/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.7/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.8/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/packages/css/package.json
+++ b/health/micro-ui-react19/web/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-health-css",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "main": "dist/index.css",
   "author": "Jagankumar <jagan.kumar@egov.org.in>",

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/NewUploadData.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/NewUploadData.js
@@ -25,7 +25,7 @@ const NewUploadData = ({ formData, onSelect, ...props }) => {
   const [downloadId, setDownloadId] = useState({});
   const [errorsType, setErrorsType] = useState({});
   const [showToast, setShowToast] = useState(null);
-  const type = props?.props?.type;
+  const type = props?.props?.screenType;
   const [executionCount, setExecutionCount] = useState(0);
   const [isError, setIsError] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadData.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadData.js
@@ -26,7 +26,7 @@ const UploadData = ({ formData, onSelect, ...props }) => {
   const [showInfoCard, setShowInfoCard] = useState(false);
   const [errorsType, setErrorsType] = useState({});
   const [showToast, setShowToast] = useState(null);
-  const type = props?.props?.type;
+  const type = props?.props?.screenType;
   const [executionCount, setExecutionCount] = useState(0);
   const [isError, setIsError] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/CampaignConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/CampaignConfig.js
@@ -257,7 +257,7 @@ export const CampaignConfig = (totalFormData, dataParams, isSubmitting, summaryE
               customProps: {
                 module: "HCM",
                 sessionData: totalFormData,
-                type: "facilityWithBoundary",
+                screenType: "facilityWithBoundary",
               },
               populators: {
                 name: "uploadFacility",
@@ -310,7 +310,7 @@ export const CampaignConfig = (totalFormData, dataParams, isSubmitting, summaryE
               customProps: {
                 module: "HCM",
                 sessionData: totalFormData,
-                type: "userWithBoundary",
+                screenType: "userWithBoundary",
               },
               populators: {
                 name: "uploadUser",
@@ -363,7 +363,7 @@ export const CampaignConfig = (totalFormData, dataParams, isSubmitting, summaryE
               customProps: {
                 module: "HCM",
                 sessionData: totalFormData,
-                type: "boundary",
+                screenType: "boundary",
               },
               populators: {
                 name: "uploadBoundary",

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/UpdateBoundaryConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/UpdateBoundaryConfig.js
@@ -18,7 +18,7 @@ export const UpdateBoundaryConfig = ({ totalFormData, hierarchyType, projectType
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "unified-console",
+                screenType: "unified-console",
               },
               populators: {
                 name: "uploadUnified",
@@ -49,7 +49,7 @@ export const UpdateBoundaryConfig = ({ totalFormData, hierarchyType, projectType
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "facility",
+                screenType: "facility",
                 projectType: projectType,
               },
               populators: {
@@ -76,7 +76,7 @@ export const UpdateBoundaryConfig = ({ totalFormData, hierarchyType, projectType
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "user",
+                screenType: "user",
                 projectType: projectType,
               },
               populators: {
@@ -103,7 +103,7 @@ export const UpdateBoundaryConfig = ({ totalFormData, hierarchyType, projectType
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "boundary",
+                screenType: "boundary",
                 projectType: projectType,
               },
               populators: {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/unifiedUploadConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/unifiedUploadConfig.js
@@ -20,7 +20,7 @@ export const unifiedUploadConfig = ({ totalFormData, campaignData }) => {
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "unified-console",
+                screenType: "unified-console",
               },
               populators: {
                 name: "uploadUnified",

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/uploadConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/uploadConfig.js
@@ -19,7 +19,7 @@ export const uploadConfig = ({ totalFormData, campaignData, summaryErrors }) => 
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "facility",
+                screenType: "facility",
               },
               populators: {
                 name: "uploadFacility",
@@ -77,7 +77,7 @@ export const uploadConfig = ({ totalFormData, campaignData, summaryErrors }) => 
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "user",
+                screenType: "user",
               },
               populators: {
                 name: "uploadUser",
@@ -134,7 +134,7 @@ export const uploadConfig = ({ totalFormData, campaignData, summaryErrors }) => 
                 module: "HCM",
                 sessionData: totalFormData,
                 campaignData: campaignData,
-                type: "boundary",
+                screenType: "boundary",
               },
               populators: {
                 name: "uploadBoundary",

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/NewUploadScreen.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/NewUploadScreen.js
@@ -169,7 +169,7 @@ const NewUploadScreen = () => {
   const onSubmit = async (formData) => {
     const step = latestConfig?.form?.[0];
     const name = step?.name; // HCM_CAMPAIGN_UPLOAD_*_DATA | DataUploadSummary
-    const type = step?.body?.[0]?.customProps?.type; // "facility" | "user" | "boundary"
+    const type = step?.body?.[0]?.customProps?.screenType; // "facility" | "user" | "boundary"
     const key = Object.keys(formData || {})?.[0];
 
     // ----- Summary validation (only nested keys considered) -----

--- a/health/micro-ui-react19/web/public/index.html
+++ b/health/micro-ui-react19/web/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-03/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.7/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.8/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>


### PR DESCRIPTION
Fix blank upload screen caused by customProps.type overriding FieldV1 type prop in digit-ui-components dev-38


**RCA :** 
In @egovernments/digit-ui-components@2.0.0-dev-38, the FieldController.js component was updated to spread config.customProps onto FieldV1:

// FieldController.js (VERSION- 38) - NEW behavior
const customProps = config?.customProps;
<FieldV1
  type={type}           // "component" ✓
  ...
  {...customProps}       // spreads { type: "unified-console" } ← OVERRIDES type!
/>

Since config files had type inside customProps (e.g., type: "unified-console", type: "facility"), this overrode FieldV1's type prop from "component" to the custom value. FieldV1's switch/case couldn't match (no case "unified-console"), so it returned null (a blank screen.)

**Fix :**

Renamed type → screenType inside customProps in 4 config files and 3 other components


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health CSS dependency from version 1.0.7 to 1.0.8 across multiple web builds.

* **Refactor**
  * Improved internal property handling within campaign upload configuration and data processing components to enhance code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->