### PR TITLE
feat(engagement): Upgrade engagement module and enable multi-root ten…

### DIFF
--- a/micro-ui/web/micro-ui-internals/example/package.json
+++ b/micro-ui/web/micro-ui-internals/example/package.json
@@ -19,7 +19,7 @@
     "@egovernments/digit-ui-module-hrms": "1.8.12",
     "@egovernments/digit-ui-module-utilities": "1.0.15",
     "@egovernments/digit-ui-module-open-payment": "0.0.2",
-    "@egovernments/digit-ui-module-engagement": "1.5.20",
+    "@egovernments/digit-ui-module-engagement": "1.8.10",
     "@egovernments/digit-ui-components": "0.2.0",
     "@egovernments/digit-ui-react-components": "1.8.22",
     "@egovernments/digit-ui-module-sandbox": "0.0.4",

--- a/micro-ui/web/micro-ui-internals/example/src/index.js
+++ b/micro-ui/web/micro-ui-internals/example/src/index.js
@@ -24,7 +24,8 @@ const enabledModules = [
   "DSS",
   "HRMS",
   "Workbench",
-  //  "Engagement", "NDSS","QuickPayLinks", "Payment",
+  "Engagement",
+  //  "NDSS","QuickPayLinks", "Payment",
   "Utilities",
   "PGR",
   //added to check fsm

--- a/micro-ui/web/micro-ui-internals/package.json
+++ b/micro-ui/web/micro-ui-internals/package.json
@@ -92,7 +92,8 @@
     "**/styled-components": "5.0.0",
     "fast-uri": "2.1.0",
     "**/minimatch": "^3.0.4",
-    "**/glob": "^7.1.2"
+    "**/glob": "^7.1.2",
+    "**/axios": "0.27.2"
   },
   "devDependencies": {
     "husky": "7.0.4",

--- a/micro-ui/web/micro-ui-internals/packages/css/src/pages/employee/index.scss
+++ b/micro-ui/web/micro-ui-internals/packages/css/src/pages/employee/index.scss
@@ -375,11 +375,13 @@
   .EventNotificationWrapper {
     @apply relative cursor-pointer ml-md;
     span {
-      top: -10px;
-      right: -10px;
-      @apply absolute bg-error h-5 w-5 rounded-full text-center;
+      top: -8px;
+      right: -8px;
+      @apply absolute bg-error h-5 w-5 rounded-full flex items-center justify-center;
       p {
-        line-height: 20px;
+        @apply text-white leading-none;
+        font-size: 11px;
+        margin: 0;
       }
     }
   }

--- a/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBar.js
+++ b/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBar.js
@@ -38,7 +38,10 @@ const TopBar = ({
     }
   }, [profilePic !== null, userDetails?.info?.uuid]);
 
-  const CitizenHomePageTenantId = Digit.ULBService.getCitizenCurrentTenant(true);
+  // For multi-root tenant, use tenant from URL; otherwise use selected home city
+  const CitizenHomePageTenantId = Digit.Utils.getMultiRootTenant() 
+    ? Digit.ULBService.getStateId() 
+    : Digit.ULBService.getCitizenCurrentTenant(true);
 
   let history = useHistory();
   const { pathname } = useLocation();

--- a/micro-ui/web/micro-ui-internals/packages/modules/engagement/src/pages/citizen/NotificationsAndWhatsNew.js
+++ b/micro-ui/web/micro-ui-internals/packages/modules/engagement/src/pages/citizen/NotificationsAndWhatsNew.js
@@ -9,7 +9,10 @@ const NotificationsAndWhatsNew = ({ variant, parentRoute }) => {
   const location = useLocation();
   const history = useHistory();
 
-  const tenantId = Digit.ULBService.getCitizenCurrentTenant();
+  // For multi-root tenant, use tenant from URL; otherwise use selected home city
+  const tenantId = Digit.Utils.getMultiRootTenant() 
+    ? Digit.ULBService.getStateId() 
+    : Digit.ULBService.getCitizenCurrentTenant();
   const {
     data: { unreadCount: preVisitUnseenNotificationCount } = {},
     isSuccess: preVisitUnseenNotificationCountLoaded,

--- a/micro-ui/web/package.json
+++ b/micro-ui/web/package.json
@@ -23,7 +23,7 @@
     "@egovernments/digit-ui-module-hrms": "1.8.12",
     "@egovernments/digit-ui-module-utilities": "1.0.15",
     "@egovernments/digit-ui-module-open-payment": "0.0.2",
-    "@egovernments/digit-ui-module-engagement": "1.5.20",
+    "@egovernments/digit-ui-module-engagement": "1.8.10",
     "@egovernments/digit-ui-components": "0.2.0",
     "@egovernments/digit-ui-react-components": "1.8.22",
     "babel-loader": "8.1.0",

--- a/micro-ui/web/sandbox/App.js
+++ b/micro-ui/web/sandbox/App.js
@@ -11,6 +11,7 @@ import { initWorkbenchComponents } from "@egovernments/digit-ui-module-workbench
   PGRReducers,
 } from "@egovernments/digit-ui-module-cms";
 import { initHRMSComponents } from "@egovernments/digit-ui-module-hrms";
+import { initEngagementComponents } from "@egovernments/digit-ui-module-engagement";
 import { overrideComponents } from "./Customisations/pgr";
 
 window.contextPath = window?.globalConfigs?.getConfig("CONTEXT_PATH");
@@ -39,6 +40,7 @@ const initDigitUI = () => {
   initPGRComponents();
   initCoreComponents();
   initHRMSComponents();
+  initEngagementComponents();
   initUtilitiesComponents();
   initWorkbenchComponents();
   initSandboxComponents();

--- a/micro-ui/web/sandbox/package.json
+++ b/micro-ui/web/sandbox/package.json
@@ -28,7 +28,7 @@
     "@egovernments/digit-ui-module-hrms": "1.8.12",
     "@egovernments/digit-ui-module-utilities": "1.0.15",
     "@egovernments/digit-ui-module-open-payment": "0.0.2",
-    "@egovernments/digit-ui-module-engagement": "1.5.20",
+    "@egovernments/digit-ui-module-engagement": "1.8.10",
     "@egovernments/digit-ui-components": "0.2.0",
     "@egovernments/digit-ui-module-sandbox": "0.0.4",
     "@egovernments/digit-ui-react-components": "1.8.22",


### PR DESCRIPTION
…ant support

- Upgrade digit-ui-module-engagement from 1.5.20 to 1.8.10 across all package.json files
- Enable Engagement module in example application by uncommenting from enabledModules
- Initialize engagement components in sandbox App.js
- Add axios 0.27.2 to resolutions for dependency consistency
- Implement multi-root tenant logic in TopBar and NotificationsAndWhatsNew components
- Use getStateId() for multi-root tenants, fallback to getCitizenCurrentTenant() for single-root
- Improve EventNotificationWrapper badge styling with better centering and typography
- Adjust badge positioning from -10px to -8px and use flexbox for proper alignment
- Update notification badge text styling with white color and smaller font size (11px)