### PR TITLE
feat(engagement): Add engagement module to sandbox and update build c…

### DIFF
--- a/micro-ui/web/sandbox/inter-package.json
+++ b/micro-ui/web/sandbox/inter-package.json
@@ -10,7 +10,8 @@
     "packages/modules/sandbox",
     "packages/modules/pgr",
     "packages/modules/dss",
-    "packages/modules/hrms"
+    "packages/modules/hrms",
+    "packages/modules/engagement"
   ],
   "author": "JaganKumar <jagan.kumar@egov.org.in>",
   "license": "MIT",
@@ -45,7 +46,7 @@
     "build:hrms": "cd packages/modules/hrms && yarn build",
     "buildD:common": "cd packages/modules/common && yarn build",
     "buildD:utilities": "cd packages/modules/utilities && yarn build",
-    "buildD:engagement": "cd packages/modules/engagement && yarn build",
+    "build:engagement": "cd packages/modules/engagement && yarn build",
     "build:sandbox": "cd packages/modules/sandbox && yarn build",
     "build:pgr": "cd packages/modules/pgr && yarn build",
     "build:workbench": "cd packages/modules/workbench && yarn build",

--- a/micro-ui/web/src/setupProxy.js
+++ b/micro-ui/web/src/setupProxy.js
@@ -7,6 +7,7 @@ module.exports = function (app) {
   [
     "/egov-mdms-service",
     "/egov-location",
+    "/egov-user-event",
     "/localization",
     "/egov-workflow-v2",
     "/pgr-services",


### PR DESCRIPTION
…ant support

- Upgrade digit-ui-module-engagement from 1.5.20 to 1.8.10 across all package.json files
- Enable Engagement module in example application by uncommenting from enabledModules
- Initialize engagement components in sandbox App.js
- Add axios 0.27.2 to resolutions for dependency consistency
- Implement multi-root tenant logic in TopBar and NotificationsAndWhatsNew components
- Use getStateId() for multi-root tenants, fallback to getCitizenCurrentTenant() for single-root
- Improve EventNotificationWrapper badge styling with better centering and typography
- Adjust badge positioning from -10px to -8px and use flexbox for proper alignment
- Update notification badge text styling with white color and smaller font size (11px)