### PR TITLE
feat(sandbox): Add engagement module to sandbox workspaces

### DIFF
--- a/micro-ui/web/sandbox/package.json
+++ b/micro-ui/web/sandbox/package.json
@@ -15,7 +15,8 @@
     "micro-ui-internals/packages/modules/sandbox",
     "micro-ui-internals/packages/modules/pgr",
     "micro-ui-internals/packages/modules/dss",
-    "micro-ui-internals/packages/modules/hrms"
+    "micro-ui-internals/packages/modules/hrms",
+    "micro-ui-internals/packages/modules/engagement"
   ],
   "homepage": "/sandbox-ui",
   "dependencies": {


### PR DESCRIPTION
- Add engagement module to the sandbox package.json workspaces array
- Enable engagement module alongside existing modules (hrms, dss, pgr)
- Align with recent engagement module integration across the platform

