### PR TITLE
Standardize logout flow and preserve user locale preference

### DIFF
--- a/micro-ui/web/micro-ui-internals/packages/libraries/src/services/elements/User/index.js
+++ b/micro-ui/web/micro-ui-internals/packages/libraries/src/services/elements/User/index.js
@@ -48,9 +48,6 @@ export const UserService = {
   },
   logout: async () => {
     const userType = UserService.getType();
-    const savedLocale = window.sessionStorage.getItem("locale") ||
-                        window.localStorage.getItem("Citizen.locale") ||
-                        window.localStorage.getItem("Employee.locale");
     try {
       await UserService.logoutUser();
     } catch (e) {
@@ -58,7 +55,6 @@ export const UserService = {
     finally{
       window.localStorage.clear();
       window.sessionStorage.clear();
-      if (savedLocale) window.sessionStorage.setItem("locale", savedLocale);
       if (userType === "citizen") {
         window.location.replace(`/${window?.contextPath}/citizen`);
       } else {

--- a/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
+++ b/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
@@ -102,15 +102,18 @@ const StaticCitizenSideBar = ({ linkData, islinkDataLoading }) => {
     toggleSidebar(false);
     setShowDialog(true);
   };
-  const handleOnSubmit = () => {
-    if (Digit.Utils.getMultiRootTenant()) {
-      Digit.UserService.logout();
-      setShowDialog(false);
-      window.location.href = `/${window?.contextPath}/citizen/login`;
-    } else {
-      Digit.UserService.logout();
-      setShowDialog(false);
+  const handleOnSubmit = async () => {
+    const savedDigitLocale = window.sessionStorage.getItem("Digit.locale");
+    try {
+      await Digit.UserService.logoutUser();
+    } catch (e) {}
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (savedDigitLocale) {
+      window.sessionStorage.setItem("Digit.locale", savedDigitLocale);
     }
+    setShowDialog(false);
+    window.location.replace(`/${window?.contextPath}/citizen`);
   };
   const handleOnCancel = () => {
     setShowDialog(false);

--- a/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/index.js
+++ b/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/index.js
@@ -26,21 +26,24 @@ const TopBarSideBar = ({
     setShowDialog(true);
   };
   const handleOnSubmit = async () => {
+    const savedDigitLocale = window.sessionStorage.getItem("Digit.locale");
+    const isSuperUserWithMultipleRootTenant = Digit?.UserService?.hasAccess("SUPERUSER") && Digit?.Utils?.getMultiRootTenant();
     try {
-      const isSuperUserWithMultipleRootTenant = Digit?.UserService?.hasAccess("SUPERUSER") && Digit?.Utils?.getMultiRootTenant();
-      if (isSuperUserWithMultipleRootTenant) {
-        try {
-          await Digit.UserService.logoutUser();
-        } catch (e) {}
-        window.localStorage.clear();
-        window.sessionStorage.clear();
-        const ts = Date.now();
-        window.location.replace(`/${window?.globalPath}/user/login?ts=${ts}`);
-      } else {
-        Digit.UserService.logout();
-      }
-    } finally {
-      setShowDialog(false);
+      await Digit.UserService.logoutUser();
+    } catch (e) {}
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (savedDigitLocale) {
+      window.sessionStorage.setItem("Digit.locale", savedDigitLocale);
+    }
+    setShowDialog(false);
+    if (isSuperUserWithMultipleRootTenant) {
+      const ts = Date.now();
+      window.location.replace(`/${window?.globalPath}/user/login?ts=${ts}`);
+    } else if (CITIZEN) {
+      window.location.replace(`/${window?.contextPath}/citizen`);
+    } else {
+      window.location.replace(`/${window?.contextPath}/employee/user/language-selection`);
     }
   };
   const handleOnCancel = () => {


### PR DESCRIPTION
- Remove locale preservation logic from UserService.logout() method
- Update StaticCitizenSideBar logout handler to directly call logoutUser() and manage storage clearing
- Refactor TopBarSideBar logout handler to consolidate logic and preserve Digit.locale across all user types
- Ensure consistent locale persistence by saving and restoring Digit.locale before clearing storage
- Simplify conditional logic for multi-root tenant and citizen redirects
- Use window.location.replace() consistently for post-logout navigation

## Choose the appropriate template for your PR:


#### Feature/Bugfix Request

**JIRA ID**  
<!-- Provide the JIRA ID or task reference -->

**Module**  
<!-- Specify the module impacted by the feature -->

**Description**  
<!-- Provide a detailed description of the feature -->

