### PR TITLE
FEATURE/HCMPRE-4042 : Multi hierarchy Selection Change

### DIFF
--- a/health/micro-ui-react19/web/builds/console/public/index.html
+++ b/health/micro-ui-react19/web/builds/console/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-05/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.15/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.16/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/builds/core-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/core-ui/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-05/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.15/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.16/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/builds/payments-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/payments-ui/public/index.html
@@ -9,7 +9,7 @@
     rel="stylesheet" type="text/css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-04/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.15/dist/index.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.16/dist/index.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-05/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.15/dist/index.css" /> 
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.16/dist/index.css" /> 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>

--- a/health/micro-ui-react19/web/packages/css/package.json
+++ b/health/micro-ui-react19/web/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-health-css",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "license": "MIT",
   "main": "dist/index.css",
   "author": "Jagankumar <jagan.kumar@egov.org.in>",

--- a/health/micro-ui-react19/web/packages/css/src/pages/employee/campaign.scss
+++ b/health/micro-ui-react19/web/packages/css/src/pages/employee/campaign.scss
@@ -1261,3 +1261,122 @@
   border-bottom-left-radius: 12px;
   border-bottom-right-radius: 12px;
 }
+.select-hierarchy-campaign-selection-cards-wrap {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+
+  .select-hierarchy-campaign-selection-card {
+    border-radius: 16px;
+    cursor: pointer;
+    background-color: #FFFFFF;
+    transition: background-color 0.15s ease;
+    min-height: 400px;
+    box-shadow: 0px 2px 7px 0px #00000026;
+
+
+    .select-hierarchy-campaign-selection-card-name {
+      font-family: var(--digitv2-fontFamily-sans);
+      font-style: var(--digitv2-fontStyle-normal);
+      font-weight: var(--digitv2-fontWeight-bold);
+      color: #0B4B66;
+
+      @media (max-aspect-ratio: 9/16) {
+        /* Media query for mobile */
+        font-size: var(--digitv2-fontSize-heading-m-mobile);
+      }
+
+      @media (min-aspect-ratio: 9/16) and (max-aspect-ratio: 3/4) {
+        /* Media query for tablets */
+        font-size: var(--digitv2-fontSize-heading-m-tablet);
+      }
+
+      @media (min-aspect-ratio: 3/4) {
+        /* Media query for desktop */
+        font-size: var(--digitv2-fontSize-heading-m-desktop);
+      }
+    }
+
+    .select-hierarchy-campaign-selection-card-level-wrap {
+      display: flex;
+      border: 1px solid #D6D5D4;
+      border-radius: 6px;
+      overflow: hidden;
+      height: 38px;
+      background-color: #FAFAFA;
+
+      .select-hierarchy-campaign-selection-card-level-name {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 10px;
+        border-right: 1px solid #D6D5D4;
+        color: #787878;
+        min-width: 44px;
+        flex-shrink: 0;
+        font-family: var(--digitv2-fontFamily-sans);
+        font-style: var(--digitv2-fontStyle-normal);
+        font-weight: var(--digitv2-fontWeight-bold);
+
+        @media (max-aspect-ratio: 9/16) {
+          /* Media query for mobile */
+          font-size: var(--digitv2-fontSize-heading-s-mobile);
+        }
+
+        @media (min-aspect-ratio: 9/16) and (max-aspect-ratio: 3/4) {
+          /* Media query for tablets */
+          font-size: var(--digitv2-fontSize-heading-s-tablet);
+        }
+
+        @media (min-aspect-ratio: 3/4) {
+          /* Media query for desktop */
+          font-size: var(--digitv2-fontSize-heading-s-desktop);
+        }
+
+      }
+
+      .select-hierarchy-campaign-selection-card-level-name-value {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 8px 10px;
+        flex: 1;
+        color: #0B4B66;
+        font-family: var(--digitv2-fontFamily-sans);
+        font-style: var(--digitv2-fontStyle-normal);
+        font-weight: var(--digitv2-fontWeight-regular);
+
+        @media (max-aspect-ratio: 9/16) {
+          /* Media query for mobile */
+          font-size: var(--digitv2-fontSize-body-s-mobile);
+        }
+
+        @media (min-aspect-ratio: 9/16) and (max-aspect-ratio: 3/4) {
+          /* Media query for tablets */
+          font-size: var(--digitv2-fontSize-body-s-tablet);
+        }
+
+        @media (min-aspect-ratio: 3/4) {
+          /* Media query for desktop */
+          font-size: var(--digitv2-fontSize-body-s-desktop);
+        }
+      }
+    }
+
+    &:active {
+      border: none !important;
+    }
+
+    &:hover {
+      box-shadow: 0px 2px 7.6px 0px #00000033;
+      background-color: #FEEFE7;
+      border: 2px solid #C84C0E;
+    }
+
+    &.selected {
+      background-color: #BAD6C9;
+      border: 2px solid #00703C;
+      box-shadow: 0px 2px 7px 0px #00000026;
+    }
+  }
+}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/Module.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/Module.js
@@ -52,6 +52,7 @@ import NoResultsFound from "./components/NoResultsFound";
 import UploadDataMappingWrapper from "./components/UploadDataMappingWrapper";
 import DataUploadWrapper from "./components/DataUploadWrapper";
 import DateSelection from "./components/CreateCampaignComponents/DateSelection";
+import SelectHierarchy from "./components/CreateCampaignComponents/SelectHierarchy";
 import ViewDetailComponent from "./components/CreateCampaignComponents/ViewDetailComponent";
 //App config import
 import AppPreview from "./components/AppPreview";
@@ -252,6 +253,7 @@ const componentsToRegister = {
   DataUploadWrapper,
   AppPreview,
   DateSelection,
+  SelectHierarchy,
   ViewDetailComponent,
   CycleSelection,
   HCMMyCampaignRowCard,

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
@@ -158,8 +158,6 @@ const SelectHierarchy = ({ onSelect, formData, ...props }) => {
     return <Loader />;
   }
 
-  console.log(hierarchyOptions,"hierarchyOptions")
-
   return (
     <React.Fragment>
       <Card>

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
@@ -1,0 +1,277 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Card, /*LabelFieldPair,*/ HeaderComponent, /*Dropdown,*/ Loader, PopUp, Button, CardText, Tag } from "@egovernments/digit-ui-components";
+
+const CONSOLE_MDMS_MODULENAME = "HCM-ADMIN-CONSOLE";
+
+const SESSION_KEYS_TO_CLEAR = [
+  "HCM_CAMPAIGN_MANAGER_FORM_DATA",
+  "HCM_CAMPAIGN_MANAGER_UPLOAD_ID",
+  "HCM_ADMIN_CONSOLE_SET_UP",
+  "HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE",
+];
+const HIERARCHY_CODE_KEY = "HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE";
+
+const hasDependentData = () => {
+  const formData = Digit.SessionStorage.get("HCM_CAMPAIGN_MANAGER_FORM_DATA") || {};
+  return !!(
+    formData.HCM_CAMPAIGN_SELECTING_BOUNDARY_DATA ||
+    formData.HCM_CAMPAIGN_UPLOAD_BOUNDARY_DATA ||
+    formData.HCM_CAMPAIGN_UPLOAD_FACILITY_DATA ||
+    formData.HCM_CAMPAIGN_UPLOAD_USER_DATA ||
+    formData.HCM_CAMPAIGN_UPLOAD_UNIFIED_DATA
+  );
+};
+
+// Sort boundary levels from root (null parent) down to leaf
+const sortBoundaryHierarchy = (boundaryHierarchy = []) => {
+  const sorted = [];
+  let currentParent = null;
+  const remaining = [...boundaryHierarchy];
+  while (remaining.length > 0) {
+    const idx = remaining.findIndex((b) => b.parentBoundaryType === currentParent);
+    if (idx === -1) break;
+    sorted.push(remaining[idx]);
+    currentParent = remaining[idx].boundaryType;
+    remaining.splice(idx, 1);
+  }
+  return sorted;
+};
+
+const SelectHierarchy = ({ onSelect, formData, ...props }) => {
+  const { t } = useTranslation();
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+
+  // All hierarchy types from MDMS
+  const { data: hierarchyOptions, isLoading: mdmsLoading } = Digit.Hooks.useCustomMDMS(
+    tenantId,
+    CONSOLE_MDMS_MODULENAME,
+    [{ name: "HierarchySchema" }],
+    {
+      select: (data) => {
+        const schemas = data?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema || [];
+        return schemas.map((item) => ({
+          code: item.type,
+          name: item.hierarchy,
+        }));
+      },
+    },
+    { schemaCode: "HierarchySchema" }
+  );
+
+  // One targeted call per hierarchyType, all fired in parallel
+  const [allHierarchyDefinitions, setAllHierarchyDefinitions] = useState([]);
+  const [definitionsLoading, setDefinitionsLoading] = useState(false);
+
+  const fetchDefinition = useCallback(
+    async (hierarchyType) => {
+      const res = await Digit.CustomService.getResponse({
+        url: `/boundary-service/boundary-hierarchy-definition/_search`,
+        body: {
+          BoundaryTypeHierarchySearchCriteria: {
+            tenantId,
+            hierarchyType,
+            limit: 1,
+            offset: 0,
+          },
+        },
+      });
+      return res?.BoundaryHierarchy?.[0] || null;
+    },
+    [tenantId]
+  );
+
+  useEffect(() => {
+    if (!hierarchyOptions?.length) return;
+    setDefinitionsLoading(true);
+    Promise.all(hierarchyOptions.map((h) => fetchDefinition(h.name)))
+      .then((results) => {
+        setAllHierarchyDefinitions(results.filter(Boolean));
+        setDefinitionsLoading(false);
+      })
+      .catch(() => setDefinitionsLoading(false));
+  }, [hierarchyOptions, fetchDefinition]);
+
+  const [selected, setSelected] = useState(
+    formData?.SelectHierarchy?.hierarchy || Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY") || null
+  );
+  const [pendingSelection, setPendingSelection] = useState(null);
+  const [showConfirmPopup, setShowConfirmPopup] = useState(false);
+  // const [dropdownKey, setDropdownKey] = useState(0); // was needed for Dropdown internal state reset
+
+  // If selected was initialized without a code (e.g. from session set by CampaignDetails which only stores name),
+  // enrich it with the code from the dedicated code key — runs once on mount
+  useEffect(() => {
+    if (selected?.name && !selected?.code) {
+      const storedCode = Digit.SessionStorage.get(HIERARCHY_CODE_KEY);
+      if (storedCode) setSelected({ name: selected.name, code: storedCode });
+    }
+  }, []);
+
+  Digit.Hooks.campaign.useBoundaryRelationshipSearch({
+    BOUNDARY_HIERARCHY_TYPE: selected?.name,
+    tenantId,
+  });
+
+  // When code is absent on either side (e.g. loaded from draft API which only stores name),
+  // fall back to name-only comparison to avoid blocking the selection display.
+  const isSameHierarchy = (a, b) => {
+    if (!a || !b) return false;
+    if (a.name !== b.name) return false;
+    if (a.code && b.code) return a.code === b.code;
+    return true;
+  };
+
+  const onHierarchySelect = (value) => {
+    if (isSameHierarchy(selected, value)) return;
+    const stored = Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY");
+    const isHierarchyChanged = stored && !isSameHierarchy(stored, value);
+    if (isHierarchyChanged && hasDependentData()) {
+      setPendingSelection(value);
+      setShowConfirmPopup(true);
+    } else {
+      setSelected(value);
+    }
+  };
+
+  const onConfirmChange = () => {
+    SESSION_KEYS_TO_CLEAR.forEach((key) => Digit.SessionStorage.del(key));
+    setSelected(pendingSelection);
+    setPendingSelection(null);
+    setShowConfirmPopup(false);
+  };
+
+  const onCancelChange = () => {
+    setPendingSelection(null);
+    setShowConfirmPopup(false);
+  };
+
+  useEffect(() => {
+    if (selected) {
+      Digit.SessionStorage.set("HCM_CAMPAIGN_SELECTED_HIERARCHY", selected);
+      if (selected.code) Digit.SessionStorage.set(HIERARCHY_CODE_KEY, selected.code);
+      onSelect("SelectHierarchy", { hierarchy: selected });
+    }
+  }, [selected]);
+
+  if (mdmsLoading || definitionsLoading) {
+    return <Loader />;
+  }
+
+  console.log(hierarchyOptions,"hierarchyOptions")
+
+  return (
+    <React.Fragment>
+      <Card>
+        <HeaderComponent styles={{}} className="digit-header-content digit-card-section-header titleStyle date-selection">
+          {t("HCM_SELECT_HIERARCHY_HEADER")}
+        </HeaderComponent>
+        <p className="dates-description digit-header-content SubHeadingClass">{t("HCM_SELECT_HIERARCHY_DESC")}</p>
+
+        {/* Old dropdown UI — kept for reference
+        <LabelFieldPair className={"boldLabel"} vertical={false} removeMargin={false}>
+          <div className="digit-header-content label" style={{ display: "flex", alignItems: "center", marginTop: "0.5rem" }}>
+            <div>{t("HCM_HIERARCHY_TYPE")}</div>
+            <span className="mandatory-date">*</span>
+          </div>
+          <Dropdown
+            key={dropdownKey}
+            t={t}
+            option={hierarchyOptions || []}
+            optionKey="name"
+            selected={selected}
+            select={onHierarchySelect}
+            isSearchable={true}
+          />
+        </LabelFieldPair>
+        */}
+
+        <div
+          className="select-hierarchy-campaign-selection-cards-wrap"
+        >
+          {hierarchyOptions?.map((hierarchy) => {
+            const definition = allHierarchyDefinitions?.find((d) => d.hierarchyType === hierarchy.name);
+            const levels = sortBoundaryHierarchy(definition?.boundaryHierarchy || []);
+            const isSelected = isSameHierarchy(selected, hierarchy);
+
+            return (
+              <Card
+                key={`${hierarchy.code}-${hierarchy.name}`}
+                onClick={() => onHierarchySelect(hierarchy)}
+                className={`select-hierarchy-campaign-selection-card ${isSelected ? "selected" : ""}`}
+              >
+                <span
+                  className={`select-hierarchy-campaign-selection-card-name`}
+                >
+                  {hierarchy.name}
+                </span>
+                {hierarchy.code && (
+                    <Tag label={hierarchy.code} type="monochrome" stroke={true} />
+                )}
+                {levels.length > 0 ? (
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px"}}>
+                    {levels.map((level, index) => (
+                      <div
+                        key={level.boundaryType}
+                        className={`select-hierarchy-campaign-selection-card-level-wrap`}
+                      >
+                        <div
+                          className={`select-hierarchy-campaign-selection-card-level-name`}
+                        >
+                          L{index + 1}
+                        </div>
+                        <div
+                          className="select-hierarchy-campaign-selection-card-level-name-value"
+                        >
+                          {t(`BOUNDARY_${level.boundaryType}`)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span style={{ fontSize: "16px", color: "#505A5F" }}>{t("HCM_NO_BOUNDARY_LEVELS")}</span>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      </Card>
+
+      {showConfirmPopup && (
+        <PopUp
+          className={"hierarchy-change-popup"}
+          type={"warning"}
+          heading={t("HCM_HIERARCHY_CHANGE_WARNING_TITLE")}
+          children={[
+            <CardText style={{ margin: 0 }}>
+              {t("HCM_HIERARCHY_CHANGE_WARNING_DESC")}
+            </CardText>,
+          ]}
+          onOverlayClick={onCancelChange}
+          onClose={onCancelChange}
+          footerChildren={[
+            <Button
+              type={"button"}
+              size={"large"}
+              variation={"secondary"}
+              label={t("HCM_HIERARCHY_CHANGE_CANCEL")}
+              title={t("HCM_HIERARCHY_CHANGE_CANCEL")}
+              onClick={onCancelChange}
+            />,
+            <Button
+              type={"button"}
+              size={"large"}
+              variation={"primary"}
+              label={t("HCM_HIERARCHY_CHANGE_CONFIRM")}
+              title={t("HCM_HIERARCHY_CHANGE_CONFIRM")}
+              onClick={onConfirmChange}
+            />,
+          ]}
+          sortFooterChildren={true}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+export default SelectHierarchy;

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/DateWithBoundary.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/DateWithBoundary.js
@@ -107,37 +107,41 @@ const DateWithBoundary = ({ onSelect, formData, ...props }) => {
   const { state } = useLocation();
   const historyState = window.history.state;
   const [selectedBoundaries, setSelectedBoundaries] = useState(null);
-  const { data: BOUNDARY_HIERARCHY_TYPE } = Digit.Hooks.useCustomMDMS(
-    tenantId,
-    CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window.Digit.Utils.campaign.getModuleName()}')]`,
-      },
-    ],
-    {
-      select: (data) => {
-        return data?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema?.[0]?.hierarchy;
+
+  // Fetch campaign data first so its hierarchyType can drive all hierarchy-dependent calls
+  const reqCriteriaProject = {
+    url: `/project-factory/v1/project-type/search`,
+    body: {
+      CampaignDetails: {
+        tenantId: tenantId,
+        ids: [campaignId],
       },
     },
-    { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
-  );
+    config: {
+      enabled: !!campaignId,
+      select: (data) => {
+        return data?.CampaignDetails?.[0];
+      },
+    },
+  };
+  const { isLoading: campaignDataLoading, data: campaignData } = Digit.Hooks.useCustomAPIHook(reqCriteriaProject);
+
+  // Campaign API is the authoritative source; session keys are fallbacks for the create flow
+  const BOUNDARY_HIERARCHY_TYPE =
+    campaignData?.hierarchyType ||
+    Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")?.name ||
+    Digit.SessionStorage.get("HCM_CAMPAIGN_MANAGER_UPLOAD_ID")?.hierarchyType;
   const { isLoading, data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window.Digit.Utils.campaign.getModuleName()}')]`,
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     { select: (MdmsRes) => MdmsRes },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
   );
   const lowestHierarchy = useMemo(() => {
-    return HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema?.[0]?.lowestHierarchy;
-  }, [HierarchySchema]);
+    const schemas = HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema || [];
+    return schemas.find((item) => item.hierarchy === BOUNDARY_HIERARCHY_TYPE)?.lowestHierarchy;
+  }, [HierarchySchema, BOUNDARY_HIERARCHY_TYPE]);
   const [hierarchyTypeDataresult, setHierarchyTypeDataresult] = useState([]);
   const [selectedLevel, setSelectedLevel] = useState(null);
   const [filteredBoundaries, setFilteredBoundaries] = useState([]);
@@ -223,24 +227,6 @@ const DateWithBoundary = ({ onSelect, formData, ...props }) => {
       setHierarchyTypeDataresult(sortedHierarchyWithLocale);
     }
   }, [hierarchyDefinition]);
-
-  const reqCriteriaProject = {
-    url: `/project-factory/v1/project-type/search`,
-    body: {
-      CampaignDetails: {
-        tenantId: tenantId,
-        ids: [campaignId],
-      },
-    },
-    config: {
-      enabled: !!campaignId,
-      select: (data) => {
-        return data?.CampaignDetails?.[0];
-      },
-    },
-  };
-
-  const { isLoading: campaignDataLoading, data: campaignData } = Digit.Hooks.useCustomAPIHook(reqCriteriaProject);
 
   useEffect(() => {
     if (state?.data) {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
@@ -26,18 +26,13 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
   const queryParams = Digit.Hooks.useQueryParams();
   const tenantId = Digit.ULBService.getStateId();
   const searchParams = new URLSearchParams(location.search);
-  const hierarchyType = props?.props?.dataParams?.hierarchyType;
+  const hierarchyType = props?.props?.dataParams?.hierarchyType || Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")?.name;
   const campaignNumber = searchParams.get("campaignNumber");
   const draft = searchParams.get("draft");
   const { data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window.Digit.Utils.campaign.getModuleName()}')]`,
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     { select: (MdmsRes) => MdmsRes },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
   );
@@ -49,8 +44,9 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.mailConfig` }
   );
   const lowestHierarchy = useMemo(() => {
-    return HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema?.[0]?.lowestHierarchy;
-  }, [HierarchySchema]);
+    const schemas = HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema || [];
+    return schemas.find((item) => item.hierarchy === hierarchyType)?.lowestHierarchy;
+  }, [HierarchySchema, hierarchyType]);
   // Initialize from session data to prevent losing data on re-render
   const [selectedData, setSelectedData] = useState(
     props?.props?.sessionData?.HCM_CAMPAIGN_SELECTING_BOUNDARY_DATA?.boundaryType?.selectedData || []
@@ -257,7 +253,15 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
         <div className="card-container-delivery">
           <Card>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-              <TagComponent campaignName={campaignName} />
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <TagComponent campaignName={campaignName} />
+                {hierarchyType && (
+                  <TagComponent
+                    campaignName={`${t("HCM_HIERARCHY_TYPE")} : ${hierarchyType}`}
+                    type="success"
+                  />
+                )}
+              </div>
               {/* Commenting Cancel Campaign feature */}
               {/* {isDraftCampaign ? (
                 <div className="digit-tag-container" style={{ margin: "0rem" }}>

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UpdateBoundaryWrapper.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UpdateBoundaryWrapper.js
@@ -18,12 +18,7 @@ const UpdateBoundaryWrapper = ({ onSelect, ...props }) => {
   const { data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window.Digit.Utils.campaign.getModuleName()}')]`,
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     { select: (MdmsRes) => MdmsRes },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
   );

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadDataMapping.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadDataMapping.js
@@ -423,7 +423,7 @@ function UploadDataMapping({ formData, onSelect, currentCategories }) {
     url: `/boundary-service/boundary-relationships/_search`,
     params: {
       tenantId: tenantId,
-      hierarchyType: paramsData?.hierarchy?.hierarchyType,
+      hierarchyType: paramsData?.hierarchy?.hierarchyType || Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")?.name,
       includeChildren: true,
       codes: allLowestHierarchyCodes?.join(","),
     },

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadDataMapping.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/UploadDataMapping.js
@@ -407,16 +407,13 @@ function UploadDataMapping({ formData, onSelect, currentCategories }) {
   const { isLoading: hierarchyLoading, data: lowestHierarchy } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: "[?(@.type=='console')]",
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     {
       enabled: true,
       select: (data) => {
-        return data?.["HCM-ADMIN-CONSOLE"]?.HierarchySchema?.[0]?.lowestHierarchy;
+        const hierarchyType = paramsData?.hierarchy?.hierarchyType || Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")?.name;
+        const schemas = data?.["HCM-ADMIN-CONSOLE"]?.HierarchySchema || [];
+        return schemas.find((item) => item.hierarchy === hierarchyType)?.lowestHierarchy;
       },
     },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/CampaignCreateConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/CampaignCreateConfig.js
@@ -115,7 +115,6 @@ export const CampaignCreateConfig = (totalFormData, editName, fromTemplate) => {
           name: "HCM_CAMPAIGN_DATE",
           subHead: "HCM_CAMPAIGN_DATE_DESC",
           sectionSubHeadClassName: "SubHeadingClass",
-          last: true,
           body: [
             {
               isMandatory: false,
@@ -137,6 +136,35 @@ export const CampaignCreateConfig = (totalFormData, editName, fromTemplate) => {
                 },
                 // optionsKey: "code",
                 error: "ES__REQUIRED_DATE",
+                required: true,
+              },
+            },
+          ],
+        },
+        {
+          stepCount: "4",
+          key: "4",
+          name: "HCM_CAMPAIGN_HIERARCHY",
+          subHead: "HCM_CAMPAIGN_HIERARCHY_DESC",
+          sectionSubHeadClassName: "SubHeadingClass",
+          last: true,
+          body: [
+            {
+              isMandatory: true,
+              key: "SelectHierarchy",
+              type: "component",
+              component: "SelectHierarchy",
+              withoutLabel: true,
+              withoutLabelFieldPair: true,
+              disable: false,
+              customProps: {
+                module: "HCM",
+                sessionData: totalFormData,
+              },
+              populators: {
+                name: "SelectHierarchy",
+                fieldPairClassName: "date-selection-field",
+                error: "ES__REQUIRED_HIERARCHY",
                 required: true,
               },
             },

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -150,24 +150,7 @@ const CampaignDetails = () => {
   const [showQRPopUp, setShowQRPopUp] = useState(false);
   const tenantId = searchParams.get("tenantId") || Digit.ULBService.getCurrentTenantId();
   const url = getMDMSUrl(true);
-  const moduleName = Digit.Utils.campaign.getModuleName();
-
-  const { data: BOUNDARY_HIERARCHY_TYPE, isLoading: hierarchyTypeLoading } = Digit.Hooks.useCustomMDMS(
-    tenantId,
-    CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${moduleName}')]`,
-      },
-    ],
-    {
-      select: (data) => {
-        return data?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema?.[0]?.hierarchy;
-      },
-    },
-    { schemaCode: "HierarchySchema" }
-  );
+  const BOUNDARY_HIERARCHY_TYPE = campaignData?.hierarchyType;
 
   const hierarchyDefinitionReqCriteria = useMemo(() => {
     return {
@@ -321,6 +304,9 @@ const CampaignDetails = () => {
     Digit.SessionStorage.set("HCM_ADMIN_CONSOLE_UPLOAD_DATA", tranformedManagerUploadData);
     Digit.SessionStorage.set("HCM_CAMPAIGN_MANAGER_UPLOAD_ID", hierarchyData);
     Digit.SessionStorage.set("HCM_ADMIN_CONSOLE_SET_UP", tranformedManagerUploadData);
+    if (campaignData?.hierarchyType) {
+      Digit.SessionStorage.set("HCM_CAMPAIGN_SELECTED_HIERARCHY", { name: campaignData.hierarchyType });
+    }
     // Update HCM_CAMPAIGN_MANAGER_FORM_DATA with fresh campaign dates for CycleConfiguration
     const existingFormData = Digit.SessionStorage.get("HCM_CAMPAIGN_MANAGER_FORM_DATA") || {};
     Digit.SessionStorage.set("HCM_CAMPAIGN_MANAGER_FORM_DATA", {
@@ -645,7 +631,7 @@ const CampaignDetails = () => {
     setShowQRPopUp(true);
   };
 
-  if (isLoading || isFormConfigLoading || hierarchyTypeLoading ) {
+  if (isLoading || isFormConfigLoading) {
     return <Loader page={true} variant={"PageLoader"} />;
   }
 
@@ -687,15 +673,11 @@ const CampaignDetails = () => {
           )}
         </div>
       </div>
-      <div style={{ display: "flex", gap: "1rem"}}>
-        <div className="dates">{week}</div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap" }}>
+        <div className="dates" style={{fontSize:"16px"}}>{week}</div>
         <div
           className="hover"
-          style={{
-            height: "20px",
-            width: "20px",
-            alignSelf: "self-end",
-          }}
+          style={{ height: "20px", width: "20px",display:"flex",alignItems:"center",justifyContent:"center",marginTop:"6px" }}
           onClick={() => {
             if (campaignData?.status === "created") {
               navigate(
@@ -708,6 +690,20 @@ const CampaignDetails = () => {
             }
           }}
           id={"campaign-details-edit-campaign-dates"}
+        >
+          <Edit width={"18"} height={"18"} />
+        </div>
+        <span style={{ color: "#D6D5D4", fontWeight: "300", fontSize: "32px", lineHeight: 1 }}>|</span>
+        <div className="dates" style={{fontSize:"16px"}}>{campaignData?.hierarchyType}</div>
+        <div
+          className="hover"
+          style={{ height: "20px", width: "20px",display:"flex",alignItems:"center",justifyContent:"center",marginTop:"6px"}}
+          onClick={() => {
+            navigate(
+              `/${window.contextPath}/employee/campaign/create-campaign?key=4&editName=${true}&id=${campaignData?.id}&draft=${isDraft}`
+            );
+          }}
+          id={"campaign-details-edit-hierarchy"}
         >
           <Edit width={"18"} height={"18"} />
         </div>

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -150,27 +150,6 @@ const CampaignDetails = () => {
   const [showQRPopUp, setShowQRPopUp] = useState(false);
   const tenantId = searchParams.get("tenantId") || Digit.ULBService.getCurrentTenantId();
   const url = getMDMSUrl(true);
-  const BOUNDARY_HIERARCHY_TYPE = campaignData?.hierarchyType;
-
-  const hierarchyDefinitionReqCriteria = useMemo(() => {
-    return {
-      url: `/boundary-service/boundary-hierarchy-definition/_search`,
-      changeQueryName: `${BOUNDARY_HIERARCHY_TYPE}`,
-      body: {
-        BoundaryTypeHierarchySearchCriteria: {
-          tenantId: tenantId,
-          limit: 2,
-          offset: 0,
-          hierarchyType: BOUNDARY_HIERARCHY_TYPE,
-        },
-      },
-      config: {
-        enabled: !!BOUNDARY_HIERARCHY_TYPE,
-      },
-    };
-  }, [tenantId, BOUNDARY_HIERARCHY_TYPE]);
-
-  const { data: hierarchyDefinition } = Digit.Hooks.useCustomAPIHook(hierarchyDefinitionReqCriteria);
 
   // useEffect(() => {
   //   window.Digit.SessionStorage.del("HCM_CAMPAIGN_MANAGER_FORM_DATA");
@@ -199,6 +178,28 @@ const CampaignDetails = () => {
   };
 
   const { isLoading, data: campaignData, isFetching } = Digit.Hooks.useCustomAPIHook(reqCriteria);
+
+  const BOUNDARY_HIERARCHY_TYPE = campaignData?.hierarchyType;
+
+  const hierarchyDefinitionReqCriteria = useMemo(() => {
+    return {
+      url: `/boundary-service/boundary-hierarchy-definition/_search`,
+      changeQueryName: `${BOUNDARY_HIERARCHY_TYPE}`,
+      body: {
+        BoundaryTypeHierarchySearchCriteria: {
+          tenantId: tenantId,
+          limit: 2,
+          offset: 0,
+          hierarchyType: BOUNDARY_HIERARCHY_TYPE,
+        },
+      },
+      config: {
+        enabled: !!BOUNDARY_HIERARCHY_TYPE,
+      },
+    };
+  }, [tenantId, BOUNDARY_HIERARCHY_TYPE]);
+
+  const { data: hierarchyDefinition } = Digit.Hooks.useCustomAPIHook(hierarchyDefinitionReqCriteria);
 
   // MDMS call for Form Config to check if all forms are configured
   const schemaCode = `${CONSOLE_MDMS_MODULENAME}.FormConfig`;

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -695,18 +695,20 @@ const CampaignDetails = () => {
         </div>
         <span style={{ color: "#D6D5D4", fontWeight: "300", fontSize: "32px", lineHeight: 1 }}>|</span>
         <div className="dates" style={{fontSize:"16px"}}>{campaignData?.hierarchyType}</div>
-        <div
-          className="hover"
-          style={{ height: "20px", width: "20px",display:"flex",alignItems:"center",justifyContent:"center",marginTop:"6px"}}
-          onClick={() => {
-            navigate(
-              `/${window.contextPath}/employee/campaign/create-campaign?key=4&editName=${true}&id=${campaignData?.id}&draft=${isDraft}`
-            );
-          }}
-          id={"campaign-details-edit-hierarchy"}
-        >
-          <Edit width={"18"} height={"18"} />
-        </div>
+        {campaignData?.status !== "created" && (
+          <div
+            className="hover"
+            style={{ height: "20px", width: "20px",display:"flex",alignItems:"center",justifyContent:"center",marginTop:"6px"}}
+            onClick={() => {
+              navigate(
+                `/${window.contextPath}/employee/campaign/create-campaign?key=4&editName=${true}&id=${campaignData?.id}&draft=${isDraft}`
+              );
+            }}
+            id={"campaign-details-edit-hierarchy"}
+          >
+            <Edit width={"18"} height={"18"} />
+          </div>
+        )}
       </div>
       <div className="detail-desc">{t(I18N_KEYS.CAMPAIGN_CREATE.HCM_VIEW_DETAILS_DESCRIPTION)}</div>
       <div className="campaign-summary-container">

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -7,7 +7,7 @@ import { CONSOLE_MDMS_MODULENAME } from "../../../Module";
 import { transformCreateData } from "../../../utils/transformCreateData";
 import { handleCreateValidate } from "../../../utils/handleCreateValidate";
 import { I18N_KEYS } from "../../../utils/i18nKeyConstants";
-const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
+const CreateCampaign = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -92,6 +92,11 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
         startDate: draftData?.startDate ? Digit.DateUtils.ConvertEpochToDate(draftData?.startDate)?.split("/")?.reverse()?.join("-") : "",
         endDate: draftData?.endDate ? Digit.DateUtils.ConvertEpochToDate(draftData?.endDate)?.split("/")?.reverse()?.join("-") : "",
       },
+      SelectHierarchy: draftData?.hierarchyType
+        ? { hierarchy: Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")?.name === draftData.hierarchyType
+            ? Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY")
+            : { name: draftData.hierarchyType } }
+        : undefined,
     };
     return restructureFormData;
   };
@@ -109,6 +114,13 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
   useEffect(() => {
     setTotalFormData(params);
   }, [params]);
+
+  useEffect(() => {
+    if (!id) {
+      Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY");
+      Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE");
+    }
+  }, []);
 
   useEffect(() => {
     updateUrlParams({ key: currentKey });
@@ -169,6 +181,7 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
   };
 
   const handleCampaignMutation = async (formData, hasDateChanged = false) => {
+    const hierarchyType = formData?.SelectHierarchy?.hierarchy?.name || params?.SelectHierarchy?.hierarchy?.name;
     setLoader(true);
     const isEdit = editName || campaignNumber;
     const mutation = isEdit ? mutationUpdate : mutationCreate;
@@ -304,8 +317,8 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
 
     const oldStartDate = normalizeDate(params?.startDate);
     const oldEndDate = normalizeDate(params?.endDate);
-    const newStartDate = formData?.DateSelection?.startDate;
-    const newEndDate = formData?.DateSelection?.endDate;
+    const newStartDate = formData?.DateSelection?.startDate ?? params?.DateSelection?.startDate;
+    const newEndDate = formData?.DateSelection?.endDate ?? params?.DateSelection?.endDate;
 
     const hasDateChanged = oldStartDate !== newStartDate || oldEndDate !== newEndDate;
 
@@ -348,7 +361,7 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
         />
       )}
       <Stepper
-        customSteps={["HCM_CAMPAIGN_TYPE_DETAILS", "HCM_CAMPAIGN_NAME_DETAILS", "HCM_CAMPAIGN_DATE_DETAILS"]}
+        customSteps={["HCM_CAMPAIGN_TYPE_DETAILS", "HCM_CAMPAIGN_NAME_DETAILS", "HCM_CAMPAIGN_DATE_DETAILS", "HCM_CAMPAIGN_HIERARCHY_DETAILS"]}
         currentStep={currentKey}
         onStepClick={onStepperClick}
         activeSteps={currentKey}
@@ -367,7 +380,7 @@ const CreateCampaign = ({ hierarchyType, hierarchyData }) => {
         secondaryLabel={t(I18N_KEYS.COMMON.HCM_BACK)}
         actionClassName={"actionBarClass"}
         className="setup-campaign"
-        noCardStyle={currentKey === 3}
+        noCardStyle={currentKey === 3 || currentKey === 4}
         onSecondayActionClick={onSecondayActionClick}
         isDisabled={isDataCreating}
         label={filteredCreateConfig?.[0]?.form?.[0]?.last === true ? t(I18N_KEYS.COMMON.HCM_SUBMIT) : t(I18N_KEYS.COMMON.HCM_NEXT)}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -27,11 +27,13 @@ import { I18N_KEYS } from "../../utils/i18nKeyConstants";
  * triggers API calls to create or update the campaign
  */
 
-const SetupCampaign = ({ hierarchyType, hierarchyData }) => {
+const SetupCampaign = ({ hierarchyType: hierarchyTypeProp, hierarchyData: hierarchyDataProp }) => {
   const resourceDatas = Digit.SessionStorage.get("HCM_ADMIN_CONSOLE_SET_UP");
   Digit.SessionStorage.set("HCM_ADMIN_CONSOLE_SET_UP", resourceDatas);
 
   const tenantId = Digit.ULBService.getCurrentTenantId();
+  const storedHierarchy = Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY");
+  const [hierarchyType, setDerivedHierarchyType] = useState(storedHierarchy?.name || hierarchyTypeProp);
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
@@ -75,18 +77,14 @@ const SetupCampaign = ({ hierarchyType, hierarchyData }) => {
   const { data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window?.Digit?.Utils?.campaign?.getModuleName()}')]`,
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     { select: (MdmsRes) => MdmsRes },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
   );
   const lowestHierarchy = useMemo(() => {
-    return HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema?.[0]?.lowestHierarchy;
-  }, [HierarchySchema]);
+    const schemas = HierarchySchema?.[CONSOLE_MDMS_MODULENAME]?.HierarchySchema || [];
+    return schemas.find((item) => item.hierarchy === hierarchyType)?.lowestHierarchy;
+  }, [HierarchySchema, hierarchyType]);
 
   const { data: DeliveryConfig } = Digit.Hooks.useCustomMDMS(
     tenantId,
@@ -116,6 +114,7 @@ const SetupCampaign = ({ hierarchyType, hierarchyData }) => {
   }, [tenantId, hierarchyType]);
 
   const { data: hierarchyDefinition } = Digit.Hooks.useCustomAPIHook(reqCriteria);
+  const hierarchyData = Digit.Hooks.campaign.useBoundaryRelationshipSearch({ BOUNDARY_HIERARCHY_TYPE: hierarchyType, tenantId });
 
   const { isLoading: draftLoading, data: draftData, error: draftError, refetch: draftRefetch } = Digit.Hooks.campaign.useSearchCampaign({
     tenantId: tenantId,
@@ -129,6 +128,13 @@ const SetupCampaign = ({ hierarchyType, hierarchyData }) => {
       },
     },
   });
+
+  useEffect(() => {
+    if (draftData?.hierarchyType && draftData.hierarchyType !== hierarchyType) {
+      setDerivedHierarchyType(draftData.hierarchyType);
+      Digit.SessionStorage.set("HCM_CAMPAIGN_SELECTED_HIERARCHY", { name: draftData.hierarchyType });
+    }
+  }, [draftData?.hierarchyType]);
 
   useEffect(() => {
     if (isPreview === "true") {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/UpdateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/UpdateCampaign.js
@@ -19,7 +19,7 @@ import { I18N_KEYS } from "../../utils/i18nKeyConstants";
  * triggers API calls to create or update the campaign
  */
 
-const UpdateCampaign = ({ hierarchyData }) => {
+const UpdateCampaign = ({ hierarchyData: hierarchyDataProp }) => {
   const resourceDatas = Digit.SessionStorage.get("HCM_ADMIN_CONSOLE_SET_UP");
   Digit.SessionStorage.set("HCM_ADMIN_CONSOLE_SET_UP", resourceDatas);
 
@@ -62,12 +62,7 @@ const UpdateCampaign = ({ hierarchyData }) => {
   const { data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
-    [
-      {
-        name: "HierarchySchema",
-        filter: `[?(@.type=='${window.Digit.Utils.campaign.getModuleName()}')]`,
-      },
-    ],
+    [{ name: "HierarchySchema" }],
     { select: (MdmsRes) => MdmsRes },
     { schemaCode: `${CONSOLE_MDMS_MODULENAME}.HierarchySchema` }
   );
@@ -122,6 +117,7 @@ const UpdateCampaign = ({ hierarchyData }) => {
   }, [tenantId, hierarchyType]);
 
   const { data: hierarchyDefinition } = Digit.Hooks.useCustomAPIHook(reqCriteria);
+  const hierarchyData = Digit.Hooks.campaign.useBoundaryRelationshipSearch({ BOUNDARY_HIERARCHY_TYPE: hierarchyType, tenantId });
 
   const { isLoading: draftLoading, data: draftData, error: draftError } = Digit.Hooks.campaign.useSearchCampaign({
     tenantId: tenantId,

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/index.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/index.js
@@ -372,7 +372,7 @@ const App = ({ path, BOUNDARY_HIERARCHY_TYPE: BoundaryHierarchy, hierarchyData: 
           <Route path={`app-config-save`} element={<AppConfigSaveLoader />} />
           <Route
             path={`create-campaign`}
-            element={<CreateCampaign hierarchyType={BOUNDARY_HIERARCHY_TYPE} hierarchyData={hierarchyData} />}
+            element={<CreateCampaign />}
           />
           <Route path={`campaign-home`} element={<CampaignHome />} />
           <Route path={`view-details`} element={<CampaignDetails />} />

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/transformCreateData.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/transformCreateData.js
@@ -28,11 +28,17 @@ export const transformCreateData = ({totalFormData, hierarchyType , params , for
     params?.additionalDetails?.cycleData?.cycleConfgureDate ||
     {};
 
+  // Detect hierarchy change — if the saved draft's hierarchyType differs from what the user just selected,
+  // boundaries and resources are no longer valid and must be cleared.
+  const hierarchyChanged = !!(params?.hierarchyType && hierarchyType && params.hierarchyType !== hierarchyType);
+
   // Transform resource types for API - unified-console should be sent as unified-console-resources
-  const transformedResources = params?.resources?.map((resource) => ({
-    ...resource,
-    type: resource?.type === "unified-console" ? "unified-console-resources" : resource?.type,
-  }));
+  const transformedResources = hierarchyChanged
+    ? []
+    : params?.resources?.map((resource) => ({
+        ...resource,
+        type: resource?.type === "unified-console" ? "unified-console-resources" : resource?.type,
+      }));
 
   // Check if resources contain unified-console-resources type
   const hasUnifiedResource = totalFormData?.additionalDetails?.isUnifiedCampaign || false;
@@ -49,8 +55,8 @@ export const transformCreateData = ({totalFormData, hierarchyType , params , for
       id: id,
       campaignName: totalFormData?.HCM_CAMPAIGN_NAME?.CampaignName || params?.CampaignName,
       resources: transformedResources,
-      boundaries: params?.boundaries,
-      deliveryRules: id && hasDateChanged ? [] : params?.deliveryRules,
+      boundaries: hierarchyChanged ? [] : params?.boundaries,
+      deliveryRules: id && (hasDateChanged || hierarchyChanged) ? [] : params?.deliveryRules,
       projectType: totalFormData?.HCM_CAMPAIGN_TYPE?.CampaignType?.code || params?.CampaignType?.code || params?.CampaignType,
       endDate: endDate,
       startDate: startDate,

--- a/health/micro-ui-react19/web/public/index.html
+++ b/health/micro-ui-react19/web/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-css@2.0.0-dev-05/dist/index.css" />
   <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-components-css@2.0.0-dev-12/dist/index.css" />
   <!-- added below css for hcm-workbench module inclusion-->
-  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.15/dist/index.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@egovernments/digit-ui-health-css@1.0.16/dist/index.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>


### PR DESCRIPTION
**JIRA ID**
HCMPRE-4042

**Module**
Campaign Manager

**Description**
Previously, the campaign module used a single hardcoded hierarchy determined by the app's module type (fetched from MDMS with a `moduleName` filter). All campaigns on an instance shared the same hierarchy regardless of what was needed. This feature allows users to **select a hierarchy during campaign creation**, and ensures every downstream screen uses that campaign's specific hierarchy.

### What's New
- **New Step 4 in Campaign Creation Wizard** — "Select Hierarchy" screen shows all available hierarchies as cards, each displaying the hierarchy name, type tag, and its boundary levels (L1 → L2 → ... → Ln)
- **Hierarchy displayed on Campaign Details** — shown beside the date field as `dates ✏️ | HierarchyType ✏️`. Edit icon is only visible for campaigns in draft state (hidden for created/live campaigns)
- **Hierarchy type tag on Boundary Selection screen** — shown alongside the campaign name tag for quick reference
- **Warning popup on hierarchy change** — if boundary selection or file uploads already exist, user is warned that changing hierarchy will clear that data

### What Changed

- Removed all MDMS `[?(@.type=='moduleName')]` filters across all components; all screens now derive `hierarchyType` from the campaign's own data or session
- `SetupCampaign`, `UpdateCampaign`, `CampaignDetails`, `DateWithBoundary`, `SelectingBoundariesDuplicate`, `UpdateBoundaryWrapper`, `UploadDataMapping`— all updated to use the campaign-specific hierarchy
- When hierarchy is changed on an existing draft, API is updated with empty `boundaries`, `resources`, and `deliveryRules` to prevent stale data from the old hierarchy being carried over

### Session Keys Introduced
| Key | Purpose |
|-----|---------|
| `HCM_CAMPAIGN_SELECTED_HIERARCHY` | Stores `{ name, code }` of selected hierarchy |
| `HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE` | Stores just the code string — persists across screens that overwrite the main key with name-only |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hierarchy selection interface to the campaign creation workflow, allowing users to select and manage hierarchy types during campaign setup with an improved card-based selection layout.

* **Chores**
  * Updated health UI stylesheet dependency to version 1.0.16 across all builds for enhanced styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->