### PR TITLE
BUGFIX/HCMPRE-4060:: Fix stale data in campaign update and increase template polling intervals

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -183,18 +183,72 @@ const CreateCampaign = () => {
     return res?.CampaignDetails;
   };
 
+  const fetchLatestCampaignData = async () => {
+    if (!id) return null;
+    const res = await Digit.CustomService.getResponse({
+      url: `/project-factory/v1/project-type/search`,
+      body: {
+        CampaignDetails: {
+          tenantId: tenantId,
+          ids: [id],
+        },
+      },
+    });
+    return res?.CampaignDetails?.[0];
+  };
+
+  const cleanupSessionAndNavigate = (campNumber, campTenantId) => {
+    Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_DATA");
+    Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_UPLOAD_DATA");
+    Digit.SessionStorage.del("HCM_CAMPAIGN_MANAGER_UPLOAD_ID");
+    Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_SET_UP");
+    Digit.SessionStorage.del("HCM_CAMPAIGN_MANAGER_FORM_DATA");
+    Digit.SessionStorage.del("CAMPAIGN_NAME_INFO_VISIBLE");
+    Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY");
+    Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE");
+    const baseUrl = `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${campNumber}&tenantId=${campTenantId}`;
+    navigate(isDraft === "true" ? `${baseUrl}&draft=true` : baseUrl);
+  };
+
   const handleCampaignMutation = async (formData, hasDateChanged = false) => {
     const sessionHierarchy = Digit.SessionStorage.get("HCM_CAMPAIGN_SELECTED_HIERARCHY");
     const hierarchyType = sessionHierarchy?.name || formData?.SelectHierarchy?.hierarchy?.name || params?.SelectHierarchy?.hierarchy?.name;
-    const hierarchyChanged = !!(params?.hierarchyType && hierarchyType && params.hierarchyType !== hierarchyType);
-    setLoader(true);
     const isEdit = !!(editName || campaignNumber || id);
+    const hierarchyChanged = !!(params?.hierarchyType && hierarchyType && params.hierarchyType !== hierarchyType);
+
+    // For edit campaigns with no hierarchy change, skip the update call entirely
+    if (isEdit && !hierarchyChanged) {
+      setShowToast({ key: "success", label: t(I18N_KEYS.PAGES.HCM_UPDATE_SUCCESS) });
+      queryClient.invalidateQueries({ queryKey: ["SEARCH_CAMPAIGN"] });
+      setTimeout(() => {
+        cleanupSessionAndNavigate(campaignNumber || params?.campaignNumber, tenantId);
+      }, 2000);
+      return;
+    }
+
+    setLoader(true);
+
+    // For edit campaigns with hierarchy change, fetch fresh campaign data from server
+    // to avoid using stale params (e.g. after a recent date update)
+    let effectiveParams = params;
+    if (isEdit && hierarchyChanged && id) {
+      try {
+        const freshData = await fetchLatestCampaignData();
+        if (freshData) {
+          effectiveParams = transformDraftDataToFormData(freshData);
+        }
+      } catch (e) {
+        // Fall back to params if fetch fails
+      }
+    }
+
     const mutation = isEdit ? mutationUpdate : mutationCreate;
     const url = isEdit ? `/project-factory/v1/project-type/update` : `/project-factory/v1/project-type/create`;
+
     const payload = transformCreateData({
       totalFormData,
       hierarchyType,
-      params,
+      params: effectiveParams,
       formData,
       ...(isEdit ? { id } : {}),
       hasDateChanged,
@@ -215,16 +269,7 @@ const CreateCampaign = () => {
           });
           queryClient.invalidateQueries({ queryKey: ["SEARCH_CAMPAIGN"] });
           setTimeout(() => {
-            Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_DATA");
-            Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_UPLOAD_DATA");
-            Digit.SessionStorage.del("HCM_CAMPAIGN_MANAGER_UPLOAD_ID");
-            Digit.SessionStorage.del("HCM_ADMIN_CONSOLE_SET_UP");
-            Digit.SessionStorage.del("HCM_CAMPAIGN_MANAGER_FORM_DATA");
-            Digit.SessionStorage.del("CAMPAIGN_NAME_INFO_VISIBLE");
-            Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY");
-            Digit.SessionStorage.del("HCM_CAMPAIGN_SELECTED_HIERARCHY_CODE");
-            const baseUrl = `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${result?.CampaignDetails?.campaignNumber}&tenantId=${result?.CampaignDetails?.tenantId}`;
-            navigate(isDraft === "true" ? `${baseUrl}&draft=true` : baseUrl);
+            cleanupSessionAndNavigate(result?.CampaignDetails?.campaignNumber, result?.CampaignDetails?.tenantId);
             setLoader(false);
           }, 2000);
         },
@@ -243,9 +288,12 @@ const CreateCampaign = () => {
     setLoader(true);
 
     const newDates = pendingFormData?.campaignDates || pendingFormData?.DateSelection;
+
     const updatedParams = {
       ...params,
       ...pendingFormData,
+      CampaignName: params?.CampaignName,
+      CampaignType: params?.CampaignType,
       DateSelection: newDates
         ? { startDate: newDates.startDate, endDate: newDates.endDate }
         : params?.DateSelection,
@@ -392,21 +440,23 @@ const CreateCampaign = () => {
 
     if (!filteredCreateConfig?.[0]?.form?.[0]?.last) {
       if (name === "HCM_CAMPAIGN_DATE" && hasDateChanged) {
-        // Clear cycle data for any date change
-        setParams((prev) => ({
-          ...prev,
-          ...dateSync,
-          additionalDetails: {
-            ...(prev?.additionalDetails || {}),
-            cycleData: [],
-            cycleConfgureDate: undefined,
-          },
-        }));
-        // Only show popup if delivery rules need clearing
-        if (params?.deliveryRules?.length > 0) {
-          setPendingFormData(formData);
-          setShowPopUp(true);
-          return;
+        // Only clear cycle data / show popup when there's existing data to clear (edit campaigns)
+        const hasExistingData = params?.deliveryRules?.length > 0 || params?.additionalDetails?.cycleData?.cycleData?.length > 0;
+        if (hasExistingData) {
+          setParams((prev) => ({
+            ...prev,
+            ...dateSync,
+            additionalDetails: {
+              ...(prev?.additionalDetails || {}),
+              cycleData: [],
+              cycleConfgureDate: undefined,
+            },
+          }));
+          if (params?.deliveryRules?.length > 0) {
+            setPendingFormData(formData);
+            setShowPopUp(true);
+            return;
+          }
         }
       }
       setShowToast(null);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/pollUtils.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/pollUtils.js
@@ -72,8 +72,8 @@ export const callTemplateDownloadByUntilCompleted = async (hierarchyType, campai
   await pollForTemplateGeneration(
     () => downloadTemplate(hierarchyType, campaignId, tenantId, type),
     conditionForTermination,
-    5000,
+    10000,
     10,
-    10000
+    20000
   );
 };

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/transformCreateData.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/utils/transformCreateData.js
@@ -15,8 +15,8 @@ export const transformCreateData = ({totalFormData, hierarchyType , params , for
 
   return dateObj.getTime(); // Epoch in milliseconds
 }
-  const startDate =  getStartDateEpoch(totalFormData?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate || params?.campaignDates?.startDate || params?.DateSelection?.startDate || formData?.DateSelection?.startDate);
-  const endDate =  Digit.Utils.date.convertDateToEpoch(totalFormData?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate || params?.campaignDates?.endDate || params?.DateSelection?.endDate || formData?.DateSelection?.endDate);
+  const startDate =  getStartDateEpoch(totalFormData?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate || totalFormData?.HCM_CAMPAIGN_DATE?.DateSelection?.startDate || params?.campaignDates?.startDate || params?.DateSelection?.startDate || formData?.DateSelection?.startDate || formData?.campaignDates?.startDate);
+  const endDate =  Digit.Utils.date.convertDateToEpoch(totalFormData?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate || totalFormData?.HCM_CAMPAIGN_DATE?.DateSelection?.endDate || params?.campaignDates?.endDate || params?.DateSelection?.endDate || formData?.DateSelection?.endDate || formData?.campaignDates?.endDate);
   const tenantId = Digit.ULBService.getCurrentTenantId();
   // Use explicit hierarchyChanged if provided by caller; otherwise detect from params.
   const hierarchyChanged = hierarchyChangedOverride ?? !!(params?.hierarchyType && hierarchyType && params.hierarchyType !== hierarchyType);


### PR DESCRIPTION


- Search fresh campaign data before hierarchy update to avoid stale name/dates in the payload. If hierarchy is unchanged, skip the update call entirely.
- Prevent draftData useEffect from overwriting user edits on refetch.
- Clear cycleData/cycleConfgureDate when dates or hierarchy change.
- Increase template download polling: firstTimeWait 10s->20s, pollInterval 5s->10s.

## Choose the appropriate template for your PR:


#### Feature/Bugfix Request

**JIRA ID**  
<!-- Provide the JIRA ID or task reference -->

**Module**  
<!-- Specify the module impacted by the feature -->

**Description**  
<!-- Provide a detailed description of the feature -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign creation and editing experience with enhanced handling of campaign hierarchy changes.
  * Better session management and user navigation after campaign operations.
  * More robust processing of campaign date fields from multiple data sources.
  * Optimized template generation polling behavior for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->