### PR TITLE
BUGFIX/HCMPRE-5005 : Fix validation toast and field matching in AppConfiguration

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/AppConfigurationWrapper.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/AppConfigurationWrapper.js
@@ -114,6 +114,13 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
     const errors = [];
     const fieldTypeMasterData = fieldTypeMaster?.fieldTypeMappingConfig || [];
 
+    // Helper: translate field label with fallback to raw fieldName if translation is missing
+    const translateFieldLabel = (field) => {
+      const code = field?.label || field?.fieldName;
+      const translated = customTranslate(code || "");
+      return translated || field?.fieldName || code || "Unknown Field";
+    };
+
     // Helper function to recursively collect all fields from nested template structures
     const collectAllFields = (node, collectedFields = []) => {
       if (!node) return collectedFields;
@@ -219,7 +226,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                   panelLabel: panelItem.label,
                   message: `VALIDATION_MANDATORY_FIELD_LOCALIZED_EMPTY`,
                   messageParams: {
-                    fieldName: customTranslate(field?.label || field?.fieldName || "Unknown Field"),
+                    fieldName: translateFieldLabel(field),
                     propertyName: t(Digit.Utils.locale.getTransformedLocale(`FIELD_DRAWER_LABEL_${panelItem?.label}`))
                   },
                   tab: tabKey,
@@ -460,7 +467,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                         panelLabel: panelItem.label,
                         message: panelItem.validationMessage,
                         messageParams: {
-                          fieldName: customTranslate(field?.label || field?.fieldName || "Unknown Field"),
+                          fieldName: translateFieldLabel(field),
                           propertyName: t(Digit.Utils.locale.getTransformedLocale(`FIELD_DRAWER_LABEL_${panelItem?.label}`))
                         },
                         tab: tabKey,
@@ -484,7 +491,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                     panelLabel: panelItem.label,
                     message: "VALIDATION_SCHEMA_CODE_REQUIRED",
                     messageParams: {
-                      fieldName: customTranslate(field?.label || field?.fieldName)
+                      fieldName: translateFieldLabel(field)
                     },
                     tab: tabKey,
                   });
@@ -500,7 +507,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                     panelLabel: panelItem.label,
                     message: "VALIDATION_DROPDOWN_OPTIONS_REQUIRED",
                     messageParams: {
-                      fieldName: customTranslate(field?.label || field?.fieldName)
+                      fieldName: translateFieldLabel(field)
                     },
                     tab: tabKey,
                   });
@@ -516,7 +523,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                       panelLabel: panelItem.label,
                       message: "VALIDATION_DROPDOWN_OPTION_NAME_REQUIRED",
                       messageParams: {
-                        fieldName: customTranslate(field?.label || field?.fieldName)
+                        fieldName: translateFieldLabel(field)
                       },
                       tab: tabKey,
                     });
@@ -532,7 +539,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                         panelLabel: panelItem.label,
                         message: "VALIDATION_DROPDOWN_OPTION_LABEL_EMPTY",
                         messageParams: {
-                          fieldName: customTranslate(field?.label || field?.fieldName)
+                          fieldName: translateFieldLabel(field)
                         },
                         tab: tabKey,
                       });
@@ -551,7 +558,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                   panelLabel: panelItem.label,
                   message: "VALIDATION_PREFIX_TEXT_MAX_LENGTH",
                   messageParams: {
-                    fieldName: customTranslate(field?.label || field?.fieldName),
+                    fieldName: translateFieldLabel(field),
                     maxLength: maxPrefixLength
                   },
                   tab: tabKey,
@@ -568,7 +575,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
                   panelLabel: panelItem.label,
                   message: "VALIDATION_SUFFIX_TEXT_MAX_LENGTH",
                   messageParams: {
-                    fieldName: customTranslate(field?.label || field?.fieldName),
+                    fieldName: translateFieldLabel(field),
                     maxLength: maxSuffixLength
                   },
                   tab: tabKey,
@@ -582,7 +589,7 @@ const AppConfigurationWrapper = ({ flow = "REGISTRATION-DELIVERY", flowName, pag
       // Validation for popup config fields
       const popupConfig = field?.properties?.popupConfig;
       if (popupConfig) {
-        const fieldLabel = customTranslate(field?.label || field?.fieldName);
+        const fieldLabel = translateFieldLabel(field);
 
         // Validate popup title - check if localized value is empty
         if (popupConfig.title) {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/NewAppFieldScreenWrapper.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/NewAppFieldScreenWrapper.js
@@ -119,8 +119,8 @@ function NewAppFieldScreenWrapper({viewMode}) {
   );
 
   const handleHideField = useCallback(
-    (fieldName, cardIndex, role) => {
-      dispatch(hideField({ fieldName, cardIndex, role }));
+    (fieldName, cardIndex, role, key) => {
+      dispatch(hideField({ fieldName, cardIndex, role, key }));
     },
     [dispatch]
   );
@@ -276,7 +276,7 @@ function NewAppFieldScreenWrapper({viewMode}) {
                   required={required}
                   isDelete={deleteFlag === true ? true : false}
                   onDelete={viewMode ? null : () => handleDeleteField(actualFieldIndex, actualCardIndex)}
-                  onHide={viewMode ? null : () => handleHideField(fieldName, actualCardIndex, rest?.role)}                  onSelectField={rest?.hidden ? null : () => handleSelectField(c[i], currentCard, card[index], actualCardIndex, actualFieldIndex)}
+                  onHide={viewMode ? null : () => handleHideField(fieldName, actualCardIndex, rest?.role, rest?.key)}                  onSelectField={rest?.hidden ? null : () => handleSelectField(c[i], currentCard, card[index], actualCardIndex, actualFieldIndex)}
                   config={c[i]}
                   Mandatory={Mandatory}
                   rest={{...rest, fieldName}}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/redux/remoteConfigSlice.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/redux/remoteConfigSlice.js
@@ -122,14 +122,14 @@ const remoteConfigSlice = createSlice({
       // Check if this is a template type page
       const isTemplate = state.currentData?.type === "template";
 
-      // Helper to recursively find field by fieldName (and optionally role) in nested template structures
-      const findFieldByName = (node, targetFieldName, targetRole) => {
+      // Helper to recursively find field by fieldName + key (and optionally role) in nested template structures
+      const findFieldByName = (node, targetFieldName, targetRole, targetKey) => {
         if (!node || !targetFieldName) return null;
 
         // Handle arrays
         if (Array.isArray(node)) {
-          for (const item of node) {
-            const found = findFieldByName(item, targetFieldName, targetRole);
+          for (let i = 0; i < node.length; i++) {
+            const found = findFieldByName(node[i], targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
           return null;
@@ -137,10 +137,18 @@ const remoteConfigSlice = createSlice({
 
         // Handle objects
         if (typeof node === "object") {
-          // Check if this node matches
+          // Check if this node matches by fieldName + key (or fieldName + role)
           if (node.fieldName === targetFieldName) {
+            // If targetKey is provided, require key match for disambiguation
+            if (targetKey !== undefined && node.key !== undefined) {
+              if (node.key !== targetKey) {
+                // Key doesn't match - continue searching
+              } else if (targetRole === undefined || node.role === targetRole) {
+                return node;
+              }
+            }
             // If targetRole is provided, also require role match (for dropdownTemplate disambiguation)
-            if (targetRole === undefined || node.role === targetRole) {
+            else if (targetRole === undefined || node.role === targetRole) {
               return node;
             }
             // Role doesn't match - continue searching
@@ -176,29 +184,33 @@ const remoteConfigSlice = createSlice({
         return null;
       };
 
-      // Check if this field is in footer by fieldName (and role if present) or label
+      // Check if this field is in footer by fieldName + key (and role if present) or label
       const isFooterField = state.currentData?.footer?.some(
-        (f) => (field?.fieldName && f.fieldName === field.fieldName && (!field?.role || f.role === field.role)) ||
+        (f) => (field?.fieldName && f.fieldName === field.fieldName &&
+               (field?.key === undefined || f.key === undefined || f.key === field.key) &&
+               (!field?.role || f.role === field.role)) ||
                (field?.label && f.label === field.label)
-      ) || (isTemplate && field?.fieldName && findFieldByName(state.currentData?.footer, field.fieldName, field.role));
+      ) || (isTemplate && field?.fieldName && findFieldByName(state.currentData?.footer, field.fieldName, field.role, field.key));
 
       let finalCardIndex = cardIndex;
       let finalFieldIndex = -1;
       let actualField = field;
 
       if (isFooterField) {
-        // For footer fields, find by fieldName first, then label
+        // For footer fields, find by fieldName + key first, then label
         finalCardIndex = -1;
         if (isTemplate && field?.fieldName) {
-          // For templates, search recursively in footer (with role disambiguation)
-          const foundField = findFieldByName(state.currentData.footer, field.fieldName, field.role);
+          // For templates, search recursively in footer (with key + role disambiguation)
+          const foundField = findFieldByName(state.currentData.footer, field.fieldName, field.role, field.key);
           if (foundField) {
             actualField = foundField;
           }
         } else {
-          // For non-templates, use flat search (with role disambiguation)
+          // For non-templates, use flat search (with key + role disambiguation)
           finalFieldIndex = state.currentData.footer.findIndex(
-            (f) => (field?.fieldName && f.fieldName === field.fieldName && (!field?.role || f.role === field.role)) ||
+            (f) => (field?.fieldName && f.fieldName === field.fieldName &&
+                   (field?.key === undefined || f.key === undefined || f.key === field.key) &&
+                   (!field?.role || f.role === field.role)) ||
                    (field?.label && f.label === field.label)
           );
           if (finalFieldIndex >= 0) {
@@ -206,12 +218,12 @@ const remoteConfigSlice = createSlice({
           }
         }
       } else if (isTemplate && field?.fieldName) {
-        // For template body fields, search by fieldName (and role) across ALL cards (ignore cardIndex)
+        // For template body fields, search by fieldName + key (and role) across ALL cards (ignore cardIndex)
         if (state.currentData?.body && Array.isArray(state.currentData.body)) {
           for (let i = 0; i < state.currentData.body.length; i++) {
             const bodyCard = state.currentData.body[i];
             if (Array.isArray(bodyCard?.fields)) {
-              const foundField = findFieldByName(bodyCard.fields, field.fieldName, field.role);
+              const foundField = findFieldByName(bodyCard.fields, field.fieldName, field.role, field.key);
               if (foundField) {
                 actualField = foundField;
                 finalCardIndex = i; // Update to actual card index where field was found
@@ -228,11 +240,19 @@ const remoteConfigSlice = createSlice({
           ) ?? -1;
         }
 
-        // Find field by fieldName first, then label (no index-based lookup)
+        // Find field by fieldName + key first, then fieldName alone, then label
         const sourceCard = state.currentData?.body?.[finalCardIndex] || card;
         if (sourceCard?.fields) {
-          // First try fieldName (with role disambiguation)
-          if (field?.fieldName) {
+          // First try fieldName + key (with role disambiguation)
+          if (field?.fieldName && field?.key !== undefined) {
+            finalFieldIndex = sourceCard.fields.findIndex(
+              (f, idx) => f.fieldName === field.fieldName &&
+                (f.key !== undefined ? f.key === field.key : idx === field.key) &&
+                (!field?.role || f.role === field.role)
+            );
+          }
+          // If not found by key, try fieldName alone (with role disambiguation)
+          if (finalFieldIndex < 0 && field?.fieldName) {
             finalFieldIndex = sourceCard.fields.findIndex(
               (f) => f.fieldName === field.fieldName && (!field?.role || f.role === field.role)
             );
@@ -308,9 +328,10 @@ const remoteConfigSlice = createSlice({
 
             // Handle objects
             if (typeof node === "object") {
-              // Check if this is the selected field (by reference, or fieldName + role)
+              // Check if this is the selected field (by reference, or fieldName + key + role)
               if (node === state.selectedField ||
                   (node.fieldName === state.selectedField.fieldName &&
+                   (state.selectedField.key === undefined || node.key === undefined || node.key === state.selectedField.key) &&
                    (!state.selectedField.role || node.role === state.selectedField.role))) {
                 // Update all properties
                 for (const key in updates) {
@@ -360,9 +381,10 @@ const remoteConfigSlice = createSlice({
 
           // Handle objects
           if (typeof node === "object") {
-            // Check if this is the selected field (by reference, or fieldName + role)
+            // Check if this is the selected field (by reference, or fieldName + key + role)
             if (node === state.selectedField ||
                 (node.fieldName === state.selectedField.fieldName &&
+                 (state.selectedField.key === undefined || node.key === undefined || node.key === state.selectedField.key) &&
                  (!state.selectedField.role || node.role === state.selectedField.role))) {
               // Update all properties
               for (const key in updates) {
@@ -666,18 +688,22 @@ const remoteConfigSlice = createSlice({
       }
     },
     hideField(state, action) {
-      const { fieldName, cardIndex, role } = action.payload;
+      const { fieldName, cardIndex, role, key } = action.payload;
 
       // Check if this is a template type page
       const isTemplate = state.currentData?.type === "template";
 
       if (!isTemplate) {
-        // For non-template types, use existing logic (with role disambiguation)
+        // For non-template types, use fieldName + key (with role disambiguation)
         const card = state.currentData?.body?.[cardIndex];
         if (!card) return;
 
         if (Array.isArray(card.fields)) {
-          const field = card.fields.find((f) => f.fieldName === fieldName && (!role || f.role === role));
+          const field = card.fields.find((f, idx) =>
+            f.fieldName === fieldName &&
+            (key === undefined || f.key === undefined ? true : (f.key !== undefined ? f.key === key : idx === key)) &&
+            (!role || f.role === role)
+          );
           if (field) {
             field.hidden = !field.hidden;
           }
@@ -697,8 +723,10 @@ const remoteConfigSlice = createSlice({
 
           // Handle objects
           if (typeof node === "object") {
-            // Check if this node has the matching fieldName (and role if provided)
-            if (node.fieldName === fieldName && (!role || node.role === role)) {
+            // Check if this node has the matching fieldName + key (and role if provided)
+            if (node.fieldName === fieldName &&
+                (key === undefined || node.key === undefined || node.key === key) &&
+                (!role || node.role === role)) {
               node.hidden = !node.hidden;
               return true;
             }

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/redux/remoteConfigSlice.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewAppConfiguration/redux/remoteConfigSlice.js
@@ -137,17 +137,16 @@ const remoteConfigSlice = createSlice({
 
         // Handle objects
         if (typeof node === "object") {
-          // Check if this node matches by fieldName + key (or fieldName + role)
+          // Check if this node matches by fieldName + key + role
           if (node.fieldName === targetFieldName) {
-            // If targetKey is provided, require key match for disambiguation
-            if (targetKey !== undefined && node.key !== undefined) {
-              if (node.key !== targetKey) {
-                // Key doesn't match - continue searching
-              } else if (targetRole === undefined || node.role === targetRole) {
+            // If targetKey is provided, require strict key match
+            if (targetKey !== undefined) {
+              if (node.key === targetKey && (targetRole === undefined || node.role === targetRole)) {
                 return node;
               }
+              // Key mismatch or missing on node - continue searching
             }
-            // If targetRole is provided, also require role match (for dropdownTemplate disambiguation)
+            // No targetKey requested - match by role only
             else if (targetRole === undefined || node.role === targetRole) {
               return node;
             }
@@ -156,27 +155,27 @@ const remoteConfigSlice = createSlice({
 
           // Check primaryAction and secondaryAction
           if (node.primaryAction) {
-            const found = findFieldByName(node.primaryAction, targetFieldName, targetRole);
+            const found = findFieldByName(node.primaryAction, targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
           if (node.secondaryAction) {
-            const found = findFieldByName(node.secondaryAction, targetFieldName, targetRole);
+            const found = findFieldByName(node.secondaryAction, targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
 
           // Recursively search in child and children
           if (node.child) {
-            const found = findFieldByName(node.child, targetFieldName, targetRole);
+            const found = findFieldByName(node.child, targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
           if (node.children) {
-            const found = findFieldByName(node.children, targetFieldName, targetRole);
+            const found = findFieldByName(node.children, targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
 
           // Also search in data object for table columns etc.
           if (node.data && typeof node.data === "object") {
-            const found = findFieldByName(node.data, targetFieldName, targetRole);
+            const found = findFieldByName(node.data, targetFieldName, targetRole, targetKey);
             if (found) return found;
           }
         }


### PR DESCRIPTION
## Summary
- Validation toast messages now show the raw `fieldName` as fallback when translation is missing, instead of showing empty text in the toast
- Field selection/update logic in `remoteConfigSlice` now uses `fieldName + key` composite for disambiguation when `key` is present on the field, with field array index as fallback

## Changes
- **AppConfigurationWrapper.js**: Added `translateFieldLabel()` helper that wraps `customTranslate()` with fallback to `fieldName`. Replaced all `customTranslate(field?.label || field?.fieldName)` calls in validation with this helper.
- **remoteConfigSlice.js**: Updated `selectField`, `updateSelectedField`, and `hideField` reducers to match fields by `fieldName + key` (when key is present) instead of `fieldName` alone.

## Test plan
- [ ] Verify toast shows readable field name when translation is missing
- [ ] Verify field selection works correctly when multiple fields share the same fieldName but have different keys
- [ ] Verify existing field selection/update behavior is not broken for fields without key property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration error messages by localizing field labels more reliably, with a clearer fallback when label information is missing.
  * Fixed field identification in configuration screens to better distinguish similarly named fields by also considering an additional field key.
  * Enhanced hide/show behavior for fields in templates and forms so the correct instance is toggled when multiple fields share the same name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->