### PR TITLE
BUGFIX/HCMPRE-5015: Fix shipment popup project selection and add Total Accepted

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityShipmentPopup.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityShipmentPopup.js
@@ -33,6 +33,7 @@ const CommodityShipmentPopup = ({
   tenantId,
   campaignId,
   campaignNumber,
+  projectId: projectIdProp,
   fromFacility,
   productVariants = [],
   selectedCommodity: defaultCommodityId,
@@ -74,8 +75,14 @@ const CommodityShipmentPopup = ({
   // Get user's projects from context (projectStaff → project search, already at correct level)
   const { projects: contextProjects } = useCommodityProject();
 
-  // User's project and its direct child project IDs (one level below)
-  const userProject = (contextProjects || [])[0];
+  // Use the selected project (passed via prop) instead of always picking the first project
+  const userProject = useMemo(() => {
+    if (!contextProjects?.length) return null;
+    if (projectIdProp) {
+      return contextProjects.find((p) => p.id === projectIdProp) || contextProjects[0];
+    }
+    return contextProjects[0];
+  }, [contextProjects, projectIdProp]);
   const userProjectId = userProject?.id;
 
   const toProjectIds = useMemo(() => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
@@ -188,7 +188,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
         stock?.additionalFields?.fields?.find((f) => f.key === "productName")?.value ||
         "Unknown";
       if (!commodityMap[productName]) {
-        commodityMap[productName] = { name: productName, totalReceived: 0, totalIssued: 0, totalReturned: 0, totalRejected: 0 };
+        commodityMap[productName] = { name: productName, totalReceived: 0, totalAccepted: 0, totalIssued: 0, totalReturned: 0, totalRejected: 0 };
       }
       if (stockEntryType === "RECEIPT") {
         // I confirmed receipt → totalReceived
@@ -215,6 +215,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
           // Only ACCEPTED counts as received for receiver (confirmation required)
           if (status === "ACCEPTED" && userFacilityIds.has(stock.receiverId)) {
             commodityMap[productName].totalReceived += qty;
+            commodityMap[productName].totalAccepted += qty;
           }
         } else if (status === "REJECTED") {
           // Rejected dispatch → sender's stock came back
@@ -243,7 +244,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
     });
     return Object.values(commodityMap).map((c) => ({
       ...c,
-      balance: c.totalReceived - c.totalIssued - c.totalReturned,
+      balance: c.totalAccepted - c.totalIssued - c.totalReturned,
     }));
   }, [finalStockData, userFacilityIds, isTopLevel, productNameMap]);
 
@@ -393,7 +394,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
     const statsMap = {};
     const getOrInit = (fId, pvId, productName) => {
       if (!statsMap[fId]) statsMap[fId] = {};
-      if (!statsMap[fId][pvId]) statsMap[fId][pvId] = { productName, totalReceived: 0, totalIssued: 0, totalRejected: 0, totalReturned: 0 };
+      if (!statsMap[fId][pvId]) statsMap[fId][pvId] = { productName, totalReceived: 0, totalAccepted: 0, totalIssued: 0, totalRejected: 0, totalReturned: 0 };
       return statsMap[fId][pvId];
     };
 
@@ -418,8 +419,10 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
         if (status === "ACCEPTED" || status === "IN_TRANSIT") {
           if (stock.senderId && descendantIds.has(stock.senderId))
             getOrInit(stock.senderId, pvId, productName).totalIssued += qty;
-          if (status === "ACCEPTED" && stock.receiverId && descendantIds.has(stock.receiverId))
+          if (status === "ACCEPTED" && stock.receiverId && descendantIds.has(stock.receiverId)) {
             getOrInit(stock.receiverId, pvId, productName).totalReceived += qty;
+            getOrInit(stock.receiverId, pvId, productName).totalAccepted += qty;
+          }
         } else if (status === "REJECTED") {
           if (stock.senderId && descendantIds.has(stock.senderId))
             getOrInit(stock.senderId, pvId, productName).totalRejected += qty;
@@ -456,10 +459,11 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
           productVariantId: pvId,
           commodity: stats.productName,
           totalReceived: stats.totalReceived,
+          totalAccepted: stats.totalAccepted,
           totalIssued: stats.totalIssued,
           totalRejected: stats.totalRejected,
           totalReturned: stats.totalReturned,
-          balance: stats.totalReceived - stats.totalIssued - stats.totalReturned,
+          balance: stats.totalAccepted - stats.totalIssued - stats.totalReturned,
         });
       });
     });
@@ -601,6 +605,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
     { label: t("HCM_BOUNDARY_HIERARCHY"),  key: "boundaryHierarchy", grow: 2.5, minWidth: "280px", sortable: false },
     { label: t("HCM_COMMODITY"),           key: "commodity",         grow: 0.8, minWidth: "120px", sortable: true },
     { label: t("HCM_TOTAL_RECEIVED"), key: "totalReceived", grow: 0.7, minWidth: "110px", sortable: true },
+    { label: t("HCM_TOTAL_ACCEPTED"), key: "totalAccepted", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t("HCM_TOTAL_ISSUED"),   key: "totalIssued",   grow: 0.7, minWidth: "110px", sortable: true },
     { label: t("HCM_TOTAL_REJECTED"), key: "totalRejected", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t("HCM_TOTAL_RETURNED"), key: "totalReturned", grow: 0.7, minWidth: "110px", sortable: true },
@@ -620,6 +625,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
       );
     },
     totalReceived: (row) => <span className="cm-cell-stock">{row.totalReceived?.toLocaleString()}</span>,
+    totalAccepted: (row) => <span className="cm-cell-stock">{row.totalAccepted?.toLocaleString()}</span>,
     totalIssued:   (row) => <span className="cm-cell-stock">{row.totalIssued?.toLocaleString()}</span>,
     totalRejected: (row) => <span className="cm-cell-stock">{row.totalRejected?.toLocaleString()}</span>,
     totalReturned: (row) => <span className="cm-cell-stock">{row.totalReturned?.toLocaleString()}</span>,
@@ -857,6 +863,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
           subtitle={commodity.name}
           items={[
             { label: "HCM_TOTAL_RECEIVED", value: commodity.totalReceived },
+            { label: "HCM_TOTAL_ACCEPTED", value: commodity.totalAccepted },
             { label: "HCM_TOTAL_ISSUED", value: commodity.totalIssued },
             { label: "HCM_TOTAL_REJECTED", value: commodity.totalRejected },
             { label: "HCM_TOTAL_RETURNED", value: commodity.totalReturned },
@@ -1019,6 +1026,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
           tenantId={tenantId}
           campaignId={campaignId}
           campaignNumber={campaignNumber}
+          projectId={projectId}
           fromFacility={shipmentFacility}
           selectedCommodity={shipmentFacility.productVariantId}
           productVariants={productVariantList}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
@@ -38,6 +38,8 @@ const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
     if (rawStatus === "ACCEPTED") status = "Returned";
     else if (rawStatus === "REJECTED") status = "Return Rejected";
     else status = "Return Initiated"; // IN_TRANSIT or unset
+  } else if (stockEntryType === "RECEIPT" || stockEntryType === "EXCESS" || stockEntryType === "LESS") {
+    status = "Received";
   }
 
   // Transaction type: RETURNED → "Reverse - Logistics", everything else → "Logistics"
@@ -212,7 +214,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
     if (!tableData?.length) return stats;
     tableData.forEach((row) => {
       stats.total++;
-      if (row.status === "Completed") stats.completed++;
+      if (row.status === "Completed" || row.status === "Received") stats.completed++;
       else if (row.status === "In-Transit" || row.status === "Return Initiated") stats.pending++;
       else if (row.status === "Rejected" || row.status === "Return Rejected") stats.rejected++;
       else if (row.status === "Returned") stats.returned++;
@@ -383,6 +385,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   const getStatusClass = (status) => {
     const classMap = {
       Completed: "cm-status-badge--completed",
+      Received: "cm-status-badge--completed",
       "In-Transit": "cm-status-badge--in-transit",
       Rejected: "cm-status-badge--rejected",
       Returned: "cm-status-badge--completed",


### PR DESCRIPTION
## Summary
- **CommodityShipmentPopup**: Fixed incorrect "To Facility" list when user has multiple projects assigned — was always using `contextProjects[0]` instead of the selected project's descendants
- **StockSummaryTab**: Added `Total Accepted` metric — counts ISSUED transactions with status=ACCEPTED where user's facility is the receiverId
- **Stock Balance formula**: Changed from `totalReceived - totalIssued - totalReturned` to `totalAccepted - totalIssued - totalReturned`

## Changes
- `CommodityShipmentPopup.js`: Accept `projectId` prop, use it to find correct project from context
- `StockSummaryTab.js`: Pass `projectId` to CommodityShipmentPopup, add `totalAccepted` to facilityCommoditySummaries, facilityStockSummaryRows, SummaryCard, summary columns, and cell renderer

## Test plan
- [ ] Verify Ship Commodity popup shows correct "To" facilities for users with multiple projects
- [ ] Verify Total Accepted count displays correctly in SummaryCard
- [ ] Verify Total Accepted column shows in Stock Summary List table
- [ ] Verify Balance = Total Accepted - Total Issued - Total Returned
- [ ] Verify single-project users are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Total Accepted** stock summary value and surfaced it in the summary view.
  * Updated balance calculations to reflect accepted quantities more accurately.
  * Enabled shipment popup flows to use the selected project when available.

* **Bug Fixes**
  * Improved project selection so downstream facility mapping and lookups use the intended project instead of always defaulting to the first one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->