### PR TITLE
BUGFIX/HCMPRE-6000: Remove RECEIPT/EXCESS/LESS double-counting from stock calculations

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/NewShipmentPopup.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/NewShipmentPopup.js
@@ -706,21 +706,7 @@ const NewShipmentPopup = ({
             init(fromFacilityId, pvId); map[fromFacilityId][pvId] += qty;
           }
         }
-      } else if (entryType === "RECEIPT") {
-        if (receiverId === fromFacilityId) {
-          // I confirmed receipt → +qty
-          init(fromFacilityId, pvId); map[fromFacilityId][pvId] += qty;
-        }
-      } else if (entryType === "EXCESS") {
-        // Received more than expected → additional stock for receiver
-        if (receiverId === fromFacilityId) {
-          init(fromFacilityId, pvId); map[fromFacilityId][pvId] += qty;
-        }
-      } else if (entryType === "LESS") {
-        // Received less than expected → reduces receiver stock
-        if (receiverId === fromFacilityId) {
-          init(fromFacilityId, pvId); map[fromFacilityId][pvId] -= qty;
-        }
+      // RECEIPT/EXCESS/LESS are duplicate entries of ISSUED/ACCEPTED — skip to avoid double-counting
       } else if (entryType === "RETURNED") {
         const retStatus = record.status || "";
         if (retStatus === "REJECTED") {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
@@ -190,21 +190,10 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
       if (!commodityMap[productName]) {
         commodityMap[productName] = { name: productName, totalReceived: 0, totalAccepted: 0, totalIssued: 0, totalReturned: 0, totalRejected: 0 };
       }
-      if (stockEntryType === "RECEIPT") {
-        // I confirmed receipt → totalReceived
-        if (userFacilityIds.has(stock.receiverId)) {
-          commodityMap[productName].totalReceived += qty;
-        }
-      } else if (stockEntryType === "EXCESS") {
-        // Received more than expected → additional stock for receiver
-        if (userFacilityIds.has(stock.receiverId)) {
-          commodityMap[productName].totalReceived += qty;
-        }
-      } else if (stockEntryType === "LESS") {
-        // Received less than expected → reduces receiver stock
-        if (userFacilityIds.has(stock.receiverId)) {
-          commodityMap[productName].totalReceived -= qty;
-        }
+      // RECEIPT/EXCESS/LESS are duplicate entries of ISSUED/ACCEPTED — skip to avoid double-counting
+      if (stockEntryType === "RECEIPT" || stockEntryType === "EXCESS" || stockEntryType === "LESS") {
+        // Ignored: receiver creates RECEIPT when accepting an ISSUED dispatch,
+        // which is already counted via ISSUED/ACCEPTED below
       } else if (stockEntryType === "ISSUED") {
         const status = stock.status || "";
         if (status === "ACCEPTED" || status === "IN_TRANSIT") {
@@ -406,15 +395,9 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
       if (!pvId) return;
       const productName = productNameMap[pvId] || stock.productName || "Unknown";
 
-      if (stockEntryType === "RECEIPT") {
-        if (stock.receiverId && descendantIds.has(stock.receiverId))
-          getOrInit(stock.receiverId, pvId, productName).totalReceived += qty;
-      } else if (stockEntryType === "EXCESS") {
-        if (stock.receiverId && descendantIds.has(stock.receiverId))
-          getOrInit(stock.receiverId, pvId, productName).totalReceived += qty;
-      } else if (stockEntryType === "LESS") {
-        if (stock.receiverId && descendantIds.has(stock.receiverId))
-          getOrInit(stock.receiverId, pvId, productName).totalReceived -= qty;
+      // RECEIPT/EXCESS/LESS are duplicate entries of ISSUED/ACCEPTED — skip to avoid double-counting
+      if (stockEntryType === "RECEIPT" || stockEntryType === "EXCESS" || stockEntryType === "LESS") {
+        // Ignored
       } else if (stockEntryType === "ISSUED") {
         if (status === "ACCEPTED" || status === "IN_TRANSIT") {
           if (stock.senderId && descendantIds.has(stock.senderId))
@@ -496,15 +479,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
           // ACCEPTED: receiver gained stock
           if (status === "ACCEPTED" && stock.receiverId) { init(stock.receiverId, pvId); map[stock.receiverId][pvId] += qty; }
         }
-      } else if (stockEntryType === "RECEIPT") {
-        // Receiver confirms receipt → gains stock
-        if (stock.receiverId) { init(stock.receiverId, pvId); map[stock.receiverId][pvId] += qty; }
-      } else if (stockEntryType === "EXCESS") {
-        // Received more than expected → additional stock for receiver
-        if (stock.receiverId) { init(stock.receiverId, pvId); map[stock.receiverId][pvId] += qty; }
-      } else if (stockEntryType === "LESS") {
-        // Received less than expected → reduces receiver stock
-        if (stock.receiverId) { init(stock.receiverId, pvId); map[stock.receiverId][pvId] -= qty; }
+      // RECEIPT/EXCESS/LESS are duplicate entries of ISSUED/ACCEPTED — skip to avoid double-counting
       } else if (stockEntryType === "RETURNED") {
         const retStatus = stock.status || "";
         if (retStatus === "REJECTED") {


### PR DESCRIPTION
## Summary
- RECEIPT, EXCESS, and LESS stock entry types are duplicate records created by the receiver alongside ISSUED/ACCEPTED for the same physical stock movement
- Counting both inflates `totalReceived` and stock balance (double-counting)
- Removed these entry types from all stock calculations across Commodity Management

## Changes
- `StockSummaryTab.js`: Skip RECEIPT/EXCESS/LESS in `facilityCommoditySummaries` (SummaryCards), `facilityStockSummaryRows` (Stock Summary List), and `facilityStockMap` (shipment validation)
- `NewShipmentPopup.js`: Skip RECEIPT/EXCESS/LESS in stock balance calculation for shipment form

## Test plan
- [ ] Verify Total Received no longer double-counts RECEIPT + ISSUED/ACCEPTED
- [ ] Verify stock balance matches the mobile app balance
- [ ] Verify Ship Commodity popup shows correct available stock
- [ ] Verify Stock Summary List table shows correct per-facility totals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stock totals to prevent double-counting in commodity and shipment summaries.
  * Improved facility balance calculations so received quantities are no longer counted more than once.
  * Updated downstream stock summaries to align with the same counting rules, making displayed balances more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->