### PR TITLE
feat(HDDF-5436): show stock rejection reason

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
@@ -10,18 +10,84 @@ import GenericChart from "./GenericChart";
 import { useCommodityProject } from "./CommodityProjectContext";
 import getProjectServiceUrl from "../../utils/getProjectServiceUrl";
 
-const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
+const normalizeStock = (stock) => stock?._source?.Data || stock?.Data || stock || {};
+
+const getStockPartyIds = (stock) => {
+  const normalizedStock = normalizeStock(stock);
+  if (normalizedStock.senderId || normalizedStock.receiverId) {
+    return {
+      senderId: normalizedStock.senderId || "",
+      receiverId: normalizedStock.receiverId || "",
+    };
+  }
+
+  if (normalizedStock.stockEntryType === "RETURNED") {
+    return {
+      senderId: normalizedStock.facilityId || "",
+      receiverId: normalizedStock.transactingFacilityId || "",
+    };
+  }
+
+  const eventType = normalizedStock.eventType || normalizedStock.transactionType;
+  const isInbound = eventType === "RECEIVED";
+  return {
+    senderId: isInbound ? normalizedStock.transactingFacilityId || "" : normalizedStock.facilityId || "",
+    receiverId: isInbound ? normalizedStock.facilityId || "" : normalizedStock.transactingFacilityId || "",
+  };
+};
+
+const transformStock = (stock, facilityNameMap = {}, productNameMap = {}, stockDetailsById = {}) => {
+  const normalizedStock = normalizeStock(stock);
+  const detailStock = stockDetailsById[normalizedStock?.id] || {};
+
   const getFieldValue = (fieldKey) => {
-    const field = stock?.additionalFields?.fields?.find(
+    const fields =
+      normalizedStock?.additionalFields?.fields ||
+      detailStock?.additionalFields?.fields ||
+      [];
+    const field = fields.find(
       (f) => f.key === fieldKey,
     );
     return field?.value || "N/A";
   };
 
-  const productName = productNameMap[stock?.productVariantId] || getFieldValue("productName");
-  const quantity = stock?.quantity || 0;
+  const { senderId, receiverId } = getStockPartyIds(
+    Object.keys(detailStock).length ? detailStock : normalizedStock,
+  );
+
+  const productVariantId =
+    normalizedStock?.productVariantId ||
+    normalizedStock?.productVariant ||
+    detailStock?.productVariantId ||
+    detailStock?.productVariant;
+  const productName =
+    productNameMap[productVariantId] ||
+    normalizedStock?.productName ||
+    detailStock?.productName ||
+    getFieldValue("productName");
+  const quantity = normalizedStock?.quantity || detailStock?.quantity || 0;
   const quantitySent = getFieldValue("quantitySent");
   const quantityReceived = getFieldValue("quantityReceived");
+  const comments =
+    normalizedStock?.comments ||
+    detailStock?.comments ||
+    normalizedStock?.reason ||
+    detailStock?.reason ||
+    normalizedStock?.additionalDetails?.comments ||
+    detailStock?.additionalDetails?.comments ||
+    normalizedStock?.additionalDetails?.comment ||
+    detailStock?.additionalDetails?.comment ||
+    normalizedStock?.additionalDetails?.remarks ||
+    detailStock?.additionalDetails?.remarks ||
+    normalizedStock?.additionalDetails?.remark ||
+    detailStock?.additionalDetails?.remark ||
+    normalizedStock?.additionalDetails?.note ||
+    detailStock?.additionalDetails?.note ||
+    getFieldValue("comments") ||
+    getFieldValue("comment") ||
+    getFieldValue("remarks") ||
+    getFieldValue("remark") ||
+    getFieldValue("note");
 
   // Build commodity string
   const commodity =
@@ -29,8 +95,18 @@ const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
 
   // Derive display status from stockEntryType + status
   // Fall back to additionalFields for stock API responses where these are not top-level
-  const stockEntryType = stock?.stockEntryType || getFieldValue("stockEntryType");
-  const rawStatus = stock?.status || getFieldValue("status");
+  const stockEntryType =
+    normalizedStock?.stockEntryType ||
+    detailStock?.stockEntryType ||
+    normalizedStock?.additionalDetails?.stockEntryType ||
+    detailStock?.additionalDetails?.stockEntryType ||
+    getFieldValue("stockEntryType");
+  const rawStatus =
+    normalizedStock?.status ||
+    detailStock?.status ||
+    normalizedStock?.additionalDetails?.status ||
+    detailStock?.additionalDetails?.status ||
+    getFieldValue("status");
   let status = "N/A";
   if (stockEntryType === "ISSUED") {
     if (rawStatus === "ACCEPTED") status = "Completed";
@@ -46,10 +122,21 @@ const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
   const txType =
     stockEntryType === "RETURNED" ? "Reverse - Logistics" : "Logistics";
 
-  const trn = stock?.id || "N/A";
+  const trn =
+    normalizedStock?.id ||
+    detailStock?.id ||
+    normalizedStock?.clientReferenceId ||
+    detailStock?.clientReferenceId ||
+    "N/A";
 
   // Format creation date
-  const createdTime = stock?.auditDetails?.createdTime;
+  const createdTime =
+    normalizedStock?.auditDetails?.createdTime ||
+    detailStock?.auditDetails?.createdTime ||
+    normalizedStock?.createdTime ||
+    detailStock?.createdTime ||
+    normalizedStock?.dateOfEntry ||
+    detailStock?.dateOfEntry;
   const creationDate = createdTime
     ? new Date(createdTime).toLocaleString("en-US", {
         year: "numeric",
@@ -66,22 +153,33 @@ const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
     trn,
     creationDate,
     createdTime,
-    sentFrom: facilityNameMap[stock?.senderId] || stock?.senderId || "N/A",
-    sentTo: facilityNameMap[stock?.receiverId] || stock?.receiverId || "N/A",
-    senderId: stock?.senderId || "",
-    receiverId: stock?.receiverId || "",
-    nameOfUser: stock?.nameOfUser || "",
-    userName: stock?.userName || "",
-    createdBy: stock?.auditDetails?.createdBy || "N/A",
+    sentFrom: facilityNameMap[senderId] || senderId || "N/A",
+    sentTo: facilityNameMap[receiverId] || receiverId || "N/A",
+    senderId,
+    receiverId,
+    nameOfUser: normalizedStock?.nameOfUser || detailStock?.nameOfUser || "",
+    userName: normalizedStock?.userName || detailStock?.userName || "",
+    createdBy:
+      normalizedStock?.auditDetails?.createdBy ||
+      detailStock?.auditDetails?.createdBy ||
+      normalizedStock?.createdBy ||
+      detailStock?.createdBy ||
+      "N/A",
     status,
     commodity,
     transactionType: txType,
-    rawTransactionType: stock?.transactionType || "N/A",
+    rawTransactionType:
+      normalizedStock?.transactionType ||
+      detailStock?.transactionType ||
+      normalizedStock?.eventType ||
+      detailStock?.eventType ||
+      "N/A",
     productName,
     quantity,
     quantitySent: quantitySent !== "N/A" ? parseInt(quantitySent) || 0 : 0,
     quantityReceived:
       quantityReceived !== "N/A" ? parseInt(quantityReceived) || 0 : 0,
+    comments: comments && comments !== "N/A" ? comments : "N/A",
   };
 };
 
@@ -102,7 +200,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   // Fetch project facilities using user's staff project
   const projectFacilityCriteria = useMemo(() => ({
     url: `${getProjectServiceUrl()}/facility/v1/_search`,
-    params: { tenantId, limit: 1500, offset: 0 },
+    params: { tenantId, limit: 100, offset: 0 },
     body: { ProjectFacility: { projectId: [userStaffProjectId] } },
     config: {
       enabled: !!userStaffProjectId && !!tenantId,
@@ -117,15 +215,48 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   }), [tenantId, userStaffProjectId]);
   const { data: projectFacilityIds = new Set(), isLoading: projectFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(projectFacilityCriteria);
 
+  // Enrich chart rows with stock API details by transaction IDs (comments are often absent in chart response)
+  const stockIds = useMemo(() => {
+    const ids = new Set();
+    (rawStockData || []).forEach((stock) => {
+      const normalizedStock = normalizeStock(stock);
+      if (normalizedStock?.id) ids.add(normalizedStock.id);
+    });
+    return [...ids];
+  }, [rawStockData]);
+
+  const stockDetailsCriteria = useMemo(
+    () => ({
+      url: `/stock/v1/_search`,
+      params: { tenantId, limit: stockIds.length || 10, offset: 0 },
+      body: { Stock: { id: stockIds } },
+      config: {
+        enabled: !!tenantId && !!stockIds.length,
+        select: (data) => {
+          const detailMap = {};
+          (data?.Stock || []).forEach((s) => {
+            if (s?.id) detailMap[s.id] = s;
+          });
+          return detailMap;
+        },
+      },
+    }),
+    [tenantId, stockIds],
+  );
+  const { data: stockDetailsById = {}, isLoading: stockDetailsLoading } = Digit.Hooks.useCustomAPIHook(stockDetailsCriteria);
+
   // Extract unique facility IDs and product variant IDs from stock data
   const { facilityIds, productVariantIds } = useMemo(() => {
     const stocks = rawStockData || [];
     const fIds = new Set();
     const pvIds = new Set();
     stocks.forEach(stock => {
-      if (stock.senderId) fIds.add(stock.senderId);
-      if (stock.receiverId) fIds.add(stock.receiverId);
-      if (stock.productVariantId) pvIds.add(stock.productVariantId);
+      const normalizedStock = normalizeStock(stock);
+      const { senderId, receiverId } = getStockPartyIds(normalizedStock);
+      if (senderId) fIds.add(senderId);
+      if (receiverId) fIds.add(receiverId);
+      const productVariantId = normalizedStock?.productVariantId || normalizedStock?.productVariant;
+      if (productVariantId) pvIds.add(productVariantId);
     });
     return { facilityIds: [...fIds], productVariantIds: [...pvIds] };
   }, [rawStockData]);
@@ -210,11 +341,12 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
     return rawStockData
       .filter(stock => {
         if (projectFacilityIds.size === 0) return false;
-        return projectFacilityIds.has(stock.senderId) || projectFacilityIds.has(stock.receiverId);
+        const { senderId, receiverId } = getStockPartyIds(stock);
+        return projectFacilityIds.has(senderId) || projectFacilityIds.has(receiverId);
       })
-      .map(stock => transformStock(stock, facilityNameMap, productNameMap))
+      .map(stock => transformStock(stock, facilityNameMap, productNameMap, stockDetailsById))
       .sort((a, b) => (b.createdTime || 0) - (a.createdTime || 0));
-  }, [rawStockData, facilityNameMap, productNameMap, projectFacilityIds]);
+  }, [rawStockData, facilityNameMap, productNameMap, projectFacilityIds, stockDetailsById]);
 
   // Compute summary stats from the facility-filtered tableData (not the unfiltered stockSummary)
   const filteredSummaryStats = useMemo(() => {
@@ -230,7 +362,13 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
     return stats;
   }, [tableData]);
 
-  const isLoading = stockLoading || facilitiesLoading || variantsLoading || productsLoading || projectFacilitiesLoading;
+  const isLoading =
+    stockLoading ||
+    facilitiesLoading ||
+    variantsLoading ||
+    productsLoading ||
+    projectFacilitiesLoading ||
+    stockDetailsLoading;
 
   const { dataSyncStats: syncStats } = stockSummary || {};
   const dataSyncStats = {
@@ -387,6 +525,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   { label: t("HCM_COMMODITY"), key: "commodity", grow: 0.8, sortable: false },
   { label: t("HCM_QUANTITY"), key: "quantity", sortType: "numeric", grow: 0.6, minWidth: "100px", sortable: true },
   { label: t("HCM_TRANSACTION_TYPE"), key: "transactionType", grow: 1, sortable: false },
+  { label: t("HCM_COMMENTS"), key: "comments", grow: 1.2, minWidth: "180px", sortable: false },
 ];
 
   // Helper to map status to CSS class

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/useKibanaStockSearch.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/useKibanaStockSearch.js
@@ -52,6 +52,13 @@ const useKibanaStockSearch = ({ tenantId, dateRange, referenceId, campaignId, ca
   const stockData = useMemo(() => {
     if (!rawRecords?.length) return [];
     return rawRecords.map((record) => {
+      const getAdditionalFieldValue = (key) => {
+        const fields = record?.additionalFields?.fields;
+        if (!Array.isArray(fields)) return undefined;
+        const field = fields.find((f) => (f?.key || "").toLowerCase() === key.toLowerCase());
+        return field?.value;
+      };
+
       const stockEntryType = record.stockEntryType || "";
       const eventType = record.eventType || record.transactionType || "";
 
@@ -72,7 +79,7 @@ const useKibanaStockSearch = ({ tenantId, dateRange, referenceId, campaignId, ca
 
       return {
         id: record.id,
-        productVariantId: record.productVariantId,
+        productVariantId: record.productVariantId || record.productVariant,
         senderId,
         receiverId,
         transactionType: record.transactionType || record.eventType,
@@ -85,11 +92,23 @@ const useKibanaStockSearch = ({ tenantId, dateRange, referenceId, campaignId, ca
         productName: record.productName,
         userName: record.userName,
         nameOfUser: record.nameOfUser,
+        reason: record.reason,
+        comments:
+          record.comments ||
+          record.additionalDetails?.comments ||
+          getAdditionalFieldValue("comments") ||
+          getAdditionalFieldValue("comment") ||
+          getAdditionalFieldValue("remarks") ||
+          getAdditionalFieldValue("remark") ||
+          getAdditionalFieldValue("note"),
         status: record.status || "",
         additionalFields: record.additionalFields || null,
+        additionalDetails: record.additionalDetails || null,
         auditDetails: {
           createdTime: record.createdTime || record.dateOfEntry,
+          createdBy: record.createdBy,
         },
+        createdBy: record.createdBy,
         boundaryHierarchyCode : record.boundaryHierarchyCode
       };
     });


### PR DESCRIPTION
**Feature/Bugfix Request**
**JIRA ID**
HDDF-5436

**Module**
Campaign Manager - Commodity Management - Warehouse Dashboard

**Description**
This PR adds visibility of stock rejection comments on the Warehouse Dashboard by introducing a new Rejection Reason column in the stock requests table.

During the Record Stock workflow, users must enter a mandatory rejection comment when selecting Reject Stock. This implementation surfaces that saved comment on the dashboard so Warehouse Managers can immediately understand why a request was declined and take corrective action.

**Implemented behavior:**
1. Adds a new Rejection Reason column in the Warehouse Dashboard table.
2. Displays the mandatory rejection comment for requests with status Rejected.
3. Shows N/A (or blank as configured) for non-rejected statuses such as Pending, Approved, and Accepted.
4. Includes Rejection Reason in dashboard export output where export is supported.
5. Places the Rejection Reason column adjacent to Status for quick visibility.

**Business outcome:**
Improves accountability and operational clarity by making rejection rationale visible directly in the dashboard without opening transaction details.