### PR TITLE
feat(health-payments): capture printed name and signature during bill…

### DIFF
--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/BillSignaturesView.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/BillSignaturesView.js
@@ -1,0 +1,87 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { formatTimestampToDateTime } from "../utils";
+
+/**
+ * Renders the sign-offs captured on a bill (printed name, signature image,
+ * role, action and date/time) wherever approval details are shown.
+ */
+const BillSignaturesView = ({ signatures }) => {
+  const { t } = useTranslation();
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+  const [urlByFileStoreId, setUrlByFileStoreId] = useState({});
+
+  const fileStoreIds = useMemo(
+    () => (signatures || []).map((s) => s?.fileStoreId).filter(Boolean),
+    [signatures]
+  );
+
+  useEffect(() => {
+    if (!fileStoreIds.length) return;
+    Digit.UploadServices.Filefetch(fileStoreIds, tenantId)
+      .then((res) => setUrlByFileStoreId(res?.data || {}))
+      .catch((err) => console.error("Failed to fetch signature images:", err));
+  }, [JSON.stringify(fileStoreIds), tenantId]);
+
+  if (!signatures || signatures.length === 0) return null;
+
+  const resolveUrl = (fileStoreId) => {
+    const value = urlByFileStoreId?.[fileStoreId];
+    if (!value) return null;
+    // filestore url responses can be comma-separated variants; take the first
+    return typeof value === "string" ? value.split(",")[0] : null;
+  };
+
+  return (
+    <div style={{ marginTop: "1.5rem" }}>
+      <span style={{ fontSize: "18px", fontWeight: 700, color: "#0B4B66" }}>{t("HCM_AM_BILL_SIGNATURES")}</span>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem", marginTop: "0.75rem" }}>
+        {signatures.map((signature, index) => {
+          const imageUrl = resolveUrl(signature?.fileStoreId);
+          return (
+            <div
+              key={signature?.id || index}
+              style={{
+                border: "1px solid #D6D5D4",
+                borderRadius: "4px",
+                padding: "0.75rem 1rem",
+                minWidth: "260px",
+                backgroundColor: "#FAFAFA",
+              }}
+            >
+              {imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt={t("HCM_AM_SIGNATURE")}
+                  style={{
+                    maxHeight: "70px",
+                    maxWidth: "220px",
+                    backgroundColor: "#FFFFFF",
+                    border: "1px solid #EEEEEE",
+                    borderRadius: "4px",
+                    display: "block",
+                    marginBottom: "0.5rem",
+                  }}
+                />
+              ) : (
+                <div style={{ color: "#505A5F", marginBottom: "0.5rem" }}>{t("HCM_AM_SIGNATURE_IMAGE_UNAVAILABLE")}</div>
+              )}
+              <div style={{ fontWeight: 700 }}>{signature?.printedName || t("NA")}</div>
+              <div style={{ color: "#505A5F", fontSize: "14px" }}>
+                {signature?.role ? t(`HCM_AM_ROLE_${signature.role}`) : t("NA")}
+              </div>
+              <div style={{ color: "#505A5F", fontSize: "14px" }}>
+                {signature?.action ? t(`HCM_AM_SIGNATURE_ACTION_${signature.action}`) : t("NA")}
+              </div>
+              <div style={{ color: "#505A5F", fontSize: "14px" }}>
+                {signature?.signedTime ? formatTimestampToDateTime(signature.signedTime) : t("NA")}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default BillSignaturesView;

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SendForApprovalPopUp.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SendForApprovalPopUp.js
@@ -2,6 +2,7 @@ import React, { useState,Fragment, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { PopUp, Button, TextArea, Toast } from "@egovernments/digit-ui-components";
 import BulkUpload from "./BulkUpload";
+import SignatureCapture from "./SignatureCapture";
 import { downloadFileWithName } from "../utils";
 
 const sanitizeComment = (value) =>
@@ -17,6 +18,10 @@ const SendForApprovalPopUp = ({ onClose, onSubmit }) => {
   const [comment, setComment] = useState("");
   const [uploadedFile, setUploadedFile] = useState([]);
   const [showToast, setShowToast] = useState(null);
+  const [signatureState, setSignatureState] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSignatureStateChange = useCallback((state) => setSignatureState(state), []);
 
   const handleUpload = useCallback(
     async (filesArray) => {
@@ -55,17 +60,51 @@ const SendForApprovalPopUp = ({ onClose, onSubmit }) => {
     onClose();
   }, [onClose]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    if (isSubmitting) return;
     setShowToast(null);
     const trimmedComment = comment.trim();
     if (!uploadedFile?.length || !trimmedComment) {
       setShowToast({ key: "error", label: t("HCM_AM_PLEASE_SELECT_MANDATORY_FIELDS") });
       return;
     }
-    onSubmit({
-      comment: trimmedComment,
-      supportingDocs: uploadedFile,
-    });
+    const printedName = signatureState?.printedName?.trim() || "";
+    if (!printedName) {
+      setShowToast({ key: "error", label: t("HCM_AM_SIGNATURE_PRINTED_NAME_REQUIRED") });
+      return;
+    }
+    if (!signatureState?.hasSignature) {
+      setShowToast({
+        key: "error",
+        label: t(signatureState?.method === "UPLOAD" ? "HCM_AM_SIGNATURE_UPLOAD_REQUIRED" : "HCM_AM_SIGNATURE_DRAW_REQUIRED"),
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const signatureFile = await signatureState.getSignatureFile();
+      if (!signatureFile) {
+        setShowToast({ key: "error", label: t("HCM_AM_SIGNATURE_DRAW_REQUIRED") });
+        return;
+      }
+      const response = await Digit.UploadServices.Filestorage("health-payments", signatureFile, tenantId);
+      const signatureFileStoreId = response?.data?.files?.[0]?.fileStoreId;
+      if (!signatureFileStoreId) {
+        setShowToast({ key: "error", label: t("HCM_AM_FILE_UPLOAD_FAILED") });
+        return;
+      }
+      onSubmit({
+        comment: trimmedComment,
+        supportingDocs: uploadedFile,
+        signature: { printedName, fileStoreId: signatureFileStoreId },
+      });
+    } catch (err) {
+      console.error("Signature upload error:", err);
+      setShowToast({ key: "error", label: t("HCM_AM_FILE_UPLOAD_FAILED") });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -103,6 +142,9 @@ const SendForApprovalPopUp = ({ onClose, onSubmit }) => {
               onChange={(e) => setComment(sanitizeComment(e.target.value))}
             />
           </div>,
+          <div key="signature-section" style={{ marginTop: "1rem" }}>
+            <SignatureCapture onStateChange={handleSignatureStateChange} />
+          </div>,
         ]}
         footerChildren={[
           <Button
@@ -126,7 +168,7 @@ const SendForApprovalPopUp = ({ onClose, onSubmit }) => {
             label={t("HCM_AM_SEND_FOR_APPROVAL")}
             title={t("HCM_AM_SEND_FOR_APPROVAL")}
             onClick={handleSave}
-            //isDisabled={!uploadedFile?.length || !comment.trim()}
+            isDisabled={isSubmitting}
           />,
         ]}
       />

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SignatureCapture.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SignatureCapture.js
@@ -1,0 +1,264 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, TextInput } from "@egovernments/digit-ui-components";
+
+const SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg"];
+const SUPPORTED_EXTENSIONS = [".png", ".jpg", ".jpeg"];
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const CANVAS_HEIGHT = 160;
+const CANVAS_SCALE = 2; // draw at 2x for print-quality signatures
+
+/**
+ * Reusable signature capture block: mandatory printed-name field plus a
+ * draw-on-canvas / upload-image toggle. Reports its state up through
+ * onStateChange; the parent extracts the final image via the provided
+ * getSignatureFile() so upload to filestore stays in the parent's control.
+ */
+const SignatureCapture = ({ onStateChange }) => {
+  const { t } = useTranslation();
+
+  const [printedName, setPrintedName] = useState("");
+  const [method, setMethod] = useState("DRAW"); // DRAW | UPLOAD
+  const [hasDrawn, setHasDrawn] = useState(false);
+  const [uploadedFile, setUploadedFile] = useState(null);
+  const [uploadPreviewUrl, setUploadPreviewUrl] = useState(null);
+  const [fileError, setFileError] = useState(null);
+
+  const canvasRef = useRef(null);
+  const isDrawingRef = useRef(false);
+  const lastPointRef = useRef(null);
+  const hasDrawnRef = useRef(false);
+  const uploadedFileRef = useRef(null);
+  const methodRef = useRef("DRAW");
+
+  useEffect(() => {
+    hasDrawnRef.current = hasDrawn;
+  }, [hasDrawn]);
+  useEffect(() => {
+    uploadedFileRef.current = uploadedFile;
+  }, [uploadedFile]);
+  useEffect(() => {
+    methodRef.current = method;
+  }, [method]);
+
+  // Resolves the signature image as a File, regardless of method
+  const getSignatureFile = useCallback(async () => {
+    if (methodRef.current === "UPLOAD") {
+      return uploadedFileRef.current || null;
+    }
+    if (!hasDrawnRef.current || !canvasRef.current) return null;
+    return new Promise((resolve) => {
+      canvasRef.current.toBlob((blob) => {
+        resolve(blob ? new File([blob], "signature.png", { type: "image/png" }) : null);
+      }, "image/png");
+    });
+  }, []);
+
+  // Push current state up whenever anything relevant changes
+  useEffect(() => {
+    onStateChange?.({
+      printedName,
+      method,
+      hasSignature: method === "DRAW" ? hasDrawn : !!uploadedFile,
+      getSignatureFile,
+    });
+  }, [printedName, method, hasDrawn, uploadedFile, getSignatureFile, onStateChange]);
+
+  // ---- Drawing canvas ----
+  const setupCanvas = useCallback((canvas) => {
+    if (!canvas) return;
+    canvasRef.current = canvas;
+    const width = canvas.parentElement ? canvas.parentElement.clientWidth : 600;
+    canvas.width = width * CANVAS_SCALE;
+    canvas.height = CANVAS_HEIGHT * CANVAS_SCALE;
+    canvas.style.width = "100%";
+    canvas.style.height = `${CANVAS_HEIGHT}px`;
+    const ctx = canvas.getContext("2d");
+    ctx.scale(CANVAS_SCALE, CANVAS_SCALE);
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = "#0B0C0C";
+  }, []);
+
+  const getPoint = (event) => {
+    const canvas = canvasRef.current;
+    const rect = canvas.getBoundingClientRect();
+    const source = event.touches ? event.touches[0] : event;
+    return { x: source.clientX - rect.left, y: source.clientY - rect.top };
+  };
+
+  const startDrawing = (event) => {
+    event.preventDefault();
+    isDrawingRef.current = true;
+    lastPointRef.current = getPoint(event);
+  };
+
+  const draw = (event) => {
+    if (!isDrawingRef.current || !canvasRef.current) return;
+    event.preventDefault();
+    const point = getPoint(event);
+    const ctx = canvasRef.current.getContext("2d");
+    ctx.beginPath();
+    ctx.moveTo(lastPointRef.current.x, lastPointRef.current.y);
+    ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+    lastPointRef.current = point;
+    if (!hasDrawnRef.current) setHasDrawn(true);
+  };
+
+  const stopDrawing = () => {
+    isDrawingRef.current = false;
+    lastPointRef.current = null;
+  };
+
+  const clearCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    setHasDrawn(false);
+  };
+
+  // ---- Upload ----
+  const handleFileSelect = (event) => {
+    setFileError(null);
+    const file = event.target.files && event.target.files[0];
+    event.target.value = ""; // allow re-selecting the same file
+    if (!file) return;
+
+    const extension = `.${(file.name.split(".").pop() || "").toLowerCase()}`;
+    if (!SUPPORTED_MIME_TYPES.includes(file.type) || !SUPPORTED_EXTENSIONS.includes(extension)) {
+      setFileError(t("HCM_AM_SIGNATURE_UNSUPPORTED_FORMAT"));
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setFileError(t("HCM_AM_SIGNATURE_FILE_TOO_LARGE"));
+      return;
+    }
+    if (uploadPreviewUrl) URL.revokeObjectURL(uploadPreviewUrl);
+    setUploadedFile(file);
+    setUploadPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const removeUploadedFile = () => {
+    if (uploadPreviewUrl) URL.revokeObjectURL(uploadPreviewUrl);
+    setUploadedFile(null);
+    setUploadPreviewUrl(null);
+    setFileError(null);
+  };
+
+  useEffect(() => () => {
+    if (uploadPreviewUrl) URL.revokeObjectURL(uploadPreviewUrl);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const methodButtonStyle = (isActive) => ({
+    padding: "0.4rem 1rem",
+    border: `1px solid ${isActive ? "#0B4B66" : "#D6D5D4"}`,
+    backgroundColor: isActive ? "#0B4B66" : "#FFFFFF",
+    color: isActive ? "#FFFFFF" : "#0B0C0C",
+    borderRadius: "4px",
+    cursor: "pointer",
+    fontWeight: 600,
+  });
+
+  return (
+    <div>
+      <div className="comment-label">
+        {t("HCM_AM_SIGNATURE_PRINTED_NAME")}
+        <span style={{ color: "red", marginLeft: "4px" }}>*</span>
+      </div>
+      <TextInput
+        type="text"
+        value={printedName}
+        onChange={(e) => setPrintedName(e.target.value)}
+        placeholder={t("HCM_AM_SIGNATURE_PRINTED_NAME_PLACEHOLDER")}
+      />
+
+      <div className="comment-label" style={{ marginTop: "1rem" }}>
+        {t("HCM_AM_SIGNATURE")}
+        <span style={{ color: "red", marginLeft: "4px" }}>*</span>
+      </div>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem" }}>
+        <button type="button" style={methodButtonStyle(method === "DRAW")} onClick={() => setMethod("DRAW")}>
+          {t("HCM_AM_SIGNATURE_DRAW")}
+        </button>
+        <button type="button" style={methodButtonStyle(method === "UPLOAD")} onClick={() => setMethod("UPLOAD")}>
+          {t("HCM_AM_SIGNATURE_UPLOAD")}
+        </button>
+      </div>
+
+      {method === "DRAW" && (
+        <div>
+          <div style={{ border: "1px dashed #B1B4B6", borderRadius: "4px", backgroundColor: "#FAFAFA" }}>
+            <canvas
+              ref={setupCanvas}
+              style={{ touchAction: "none", display: "block", cursor: "crosshair" }}
+              onMouseDown={startDrawing}
+              onMouseMove={draw}
+              onMouseUp={stopDrawing}
+              onMouseLeave={stopDrawing}
+              onTouchStart={startDrawing}
+              onTouchMove={draw}
+              onTouchEnd={stopDrawing}
+            />
+          </div>
+          <div style={{ marginTop: "0.5rem" }}>
+            <Button
+              type="button"
+              size="small"
+              variation="secondary"
+              label={t("HCM_AM_SIGNATURE_CLEAR")}
+              title={t("HCM_AM_SIGNATURE_CLEAR")}
+              onClick={clearCanvas}
+              isDisabled={!hasDrawn}
+            />
+          </div>
+        </div>
+      )}
+
+      {method === "UPLOAD" && (
+        <div>
+          {!uploadedFile ? (
+            <label
+              style={{
+                display: "inline-block",
+                padding: "0.5rem 1rem",
+                border: "1px solid #0B4B66",
+                borderRadius: "4px",
+                color: "#0B4B66",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              {t("HCM_AM_SIGNATURE_CHOOSE_FILE")}
+              <input type="file" accept=".png,.jpg,.jpeg,image/png,image/jpeg" style={{ display: "none" }} onChange={handleFileSelect} />
+            </label>
+          ) : (
+            <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+              <img
+                src={uploadPreviewUrl}
+                alt={t("HCM_AM_SIGNATURE")}
+                style={{ maxHeight: "80px", maxWidth: "240px", border: "1px solid #D6D5D4", borderRadius: "4px", backgroundColor: "#FFFFFF" }}
+              />
+              <span style={{ wordBreak: "break-all" }}>{uploadedFile.name}</span>
+              <Button
+                type="button"
+                size="small"
+                variation="secondary"
+                label={t("HCM_AM_SIGNATURE_REMOVE")}
+                title={t("HCM_AM_SIGNATURE_REMOVE")}
+                onClick={removeUploadedFile}
+              />
+            </div>
+          )}
+          <div style={{ marginTop: "0.25rem", fontSize: "12px", color: "#505A5F" }}>{t("HCM_AM_SIGNATURE_UPLOAD_HINT")}</div>
+          {fileError && <div style={{ marginTop: "0.25rem", color: "#B91900", fontWeight: 600 }}>{fileError}</div>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SignatureCapture;

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SignaturePopUp.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/components/SignaturePopUp.js
@@ -1,0 +1,108 @@
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PopUp, Button, Toast } from "@egovernments/digit-ui-components";
+import SignatureCapture from "./SignatureCapture";
+
+/**
+ * Sign-off dialog shown before a bill workflow action completes.
+ * Collects the mandatory printed name and a drawn or uploaded signature,
+ * uploads the image to filestore and hands {printedName, fileStoreId}
+ * back through onSubmit. The action is not performed until both are valid.
+ */
+const SignaturePopUp = ({ heading, description, submitLabel, onClose, onSubmit }) => {
+  const { t } = useTranslation();
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+
+  const [signatureState, setSignatureState] = useState(null);
+  const [showToast, setShowToast] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleStateChange = useCallback((state) => setSignatureState(state), []);
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
+    setShowToast(null);
+
+    const printedName = signatureState?.printedName?.trim() || "";
+    if (!printedName) {
+      setShowToast({ key: "error", label: t("HCM_AM_SIGNATURE_PRINTED_NAME_REQUIRED") });
+      return;
+    }
+    if (!signatureState?.hasSignature) {
+      setShowToast({
+        key: "error",
+        label: t(signatureState?.method === "UPLOAD" ? "HCM_AM_SIGNATURE_UPLOAD_REQUIRED" : "HCM_AM_SIGNATURE_DRAW_REQUIRED"),
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const file = await signatureState.getSignatureFile();
+      if (!file) {
+        setShowToast({ key: "error", label: t("HCM_AM_SIGNATURE_DRAW_REQUIRED") });
+        return;
+      }
+      const response = await Digit.UploadServices.Filestorage("health-payments", file, tenantId);
+      const fileStoreId = response?.data?.files?.[0]?.fileStoreId;
+      if (!fileStoreId) {
+        setShowToast({ key: "error", label: t("HCM_AM_FILE_UPLOAD_FAILED") });
+        return;
+      }
+      onSubmit({ printedName, fileStoreId });
+    } catch (err) {
+      console.error("Signature upload error:", err);
+      setShowToast({ key: "error", label: t("HCM_AM_FILE_UPLOAD_FAILED") });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <PopUp
+        style={{ width: "700px" }}
+        onClose={onClose}
+        heading={heading || t("HCM_AM_SIGNATURE_POPUP_HEADING")}
+        onOverlayClick={onClose}
+        equalWidthButtons={true}
+        children={[
+          <div key="signature-popup-description" style={{ marginBottom: "1rem" }}>
+            {description || t("HCM_AM_SIGNATURE_POPUP_DESCRIPTION")}
+          </div>,
+          <SignatureCapture key="signature-capture" onStateChange={handleStateChange} />,
+        ]}
+        footerChildren={[
+          <Button
+            key="cancel-button"
+            className="campaign-type-alert-button"
+            type="button"
+            size="large"
+            style={{ minWidth: "270px" }}
+            variation="secondary"
+            label={t("HCM_AM_CANCEL")}
+            title={t("HCM_AM_CANCEL")}
+            onClick={onClose}
+          />,
+          <Button
+            key="submit-button"
+            className="campaign-type-alert-button"
+            type="button"
+            size="large"
+            variation="primary"
+            style={{ minWidth: "270px" }}
+            label={submitLabel || t("HCM_AM_SIGNATURE_SUBMIT")}
+            title={submitLabel || t("HCM_AM_SIGNATURE_SUBMIT")}
+            onClick={handleSubmit}
+            isDisabled={isSubmitting}
+          />,
+        ]}
+      />
+      {showToast && (
+        <Toast style={{ zIndex: 10001 }} label={showToast.label} type={showToast.key} onClose={() => setShowToast(null)} />
+      )}
+    </>
+  );
+};
+
+export default SignaturePopUp;

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/pages/employee/bill_payment_details.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/pages/employee/bill_payment_details.js
@@ -28,6 +28,8 @@ import "./loader_size.css";
 import { getManageBillsRole, getManageBillsConfig, MANAGE_BILLS_ROLE_STORAGE_KEY, normalizeManageBillsRoleParam } from "../../utils/roleUtils";
 import { MANAGE_BILLS_ROLES } from "../../config/manageBillsRoleConfig";
 import SendForApprovalPopUp from "../../components/SendForApprovalPopUp";
+import SignaturePopUp from "../../components/SignaturePopUp";
+import BillSignaturesView from "../../components/BillSignaturesView";
 
 // Fallback view map (used when role config is not available)
 const BILL_STATUS_VIEW = {
@@ -168,6 +170,8 @@ const BillPaymentDetails = ({ editBillDetails = false }) => {
   const [openReviewerEditWarningPopUp, setOpenReviewerEditWarningPopUp] = useState(false);
   const [openSendForApprovalPopUp, setOpenSendForApprovalPopUp] = useState(false);
   const [openSendForReviewPopUp, setOpenSendForReviewPopUp] = useState(false);
+  // Pending workflow action awaiting the mandatory sign-off (printed name + signature)
+  const [signatureFlow, setSignatureFlow] = useState(null);
   const [openSaveChangesPopUp, setOpenSaveChangesPopUp] = useState(false);
   // --------------------
 // Report (PDF / EXCEL)
@@ -607,7 +611,7 @@ const BillPaymentDetails = ({ editBillDetails = false }) => {
     }
   }
 
-  const triggerUpdateBill = async (bill, action) => {
+  const triggerUpdateBill = async (bill, action, signature = null) => {
     try {
       await bulkUpdateMutation.mutateAsync(
         {
@@ -620,6 +624,7 @@ const BillPaymentDetails = ({ editBillDetails = false }) => {
               comments: `Bill ${action} triggered`,
               assignes: [],
             },
+            ...(signature ? { signature } : {}),
           },
         },
         {
@@ -1742,6 +1747,7 @@ const downloadOptions = [
               billData?.additionalDetails?.justificationDetails?.comment
                 ? renderLabelPair("HCM_AM_PAYMENT_REVIEWER_COMMENTS", billData?.additionalDetails?.justificationDetails?.comment, { whiteSpace: "pre-wrap" })
                 : null}
+              <BillSignaturesView signatures={billData?.signatures} />
 
  {/* uncomment this block to show report generation and download section               */}
 {/* <div>
@@ -2021,10 +2027,11 @@ const downloadOptions = [
       {openSendForApprovalPopUp && (
         <SendForApprovalPopUp
           onClose={() => setOpenSendForApprovalPopUp(false)}
-          onSubmit={({ comment, supportingDocs }) => {
+          onSubmit={({ comment, supportingDocs, signature }) => {
             setOpenSendForApprovalPopUp(false);
             const updatedBill = {
               ...billData,
+              signatures: [...(billData?.signatures || []), signature],
               additionalDetails: {
                 ...(billData?.additionalDetails || {}),
                 justificationDetails: {
@@ -2303,10 +2310,21 @@ const downloadOptions = [
         cancelLabel={t("HCM_AM_CANCEL")}
         onPrimaryAction={() => {
           setOpenSendForReviewPopUp(false);
-          triggerUpdateBill(billData, "SEND_FOR_REVIEW");
-          // setShowToast({ key: "success", label: t("HCM_AM_SEND_FOR_REVIEW_SUCCESS"), transitionTime: 3000 });
+          setSignatureFlow({ action: "SEND_FOR_REVIEW" });
         }}
       />}
+      {signatureFlow && (
+        <SignaturePopUp
+          heading={t(`HCM_AM_SIGNATURE_POPUP_HEADING_${signatureFlow.action}`)}
+          submitLabel={t(`HCM_AM_${signatureFlow.action}`)}
+          onClose={() => setSignatureFlow(null)}
+          onSubmit={(signature) => {
+            const { action } = signatureFlow;
+            setSignatureFlow(null);
+            triggerUpdateBill(billData, action, signature);
+          }}
+        />
+      )}
       {openSaveChangesPopUp && <AlertPopUp
         onClose={() => setOpenSaveChangesPopUp(false)}
         alertHeading={t("HCM_AM_CONFIRM_SAVE_CHANGES")}

--- a/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/pages/employee/manage_bills.js
+++ b/health/micro-ui/web/micro-ui-internals/packages/modules/health-payments/src/pages/employee/manage_bills.js
@@ -14,6 +14,7 @@ import _ from "lodash";
 import { getManageBillsRole, getManageBillsConfig, MANAGE_BILLS_ROLE_STORAGE_KEY, normalizeManageBillsRoleParam } from "../../utils/roleUtils";
 import { MANAGE_BILLS_ROLES } from "../../config/manageBillsRoleConfig";
 import AlertPopUp from "../../components/alertPopUp";
+import SignaturePopUp from "../../components/SignaturePopUp";
 
 const ManageBills = () => {
   const { t } = useTranslation();
@@ -24,6 +25,8 @@ const ManageBills = () => {
   const [selectedBills, setSelectedBills] = useState([]);
   const [clearSelectedRows, setClearSelectedRows] = useState(false);
   const [activePopUpAction, setActivePopUpAction] = useState(null);
+  // Bulk workflow action awaiting the mandatory sign-off (printed name + signature)
+  const [signatureFlow, setSignatureFlow] = useState(null);
 
   // Role-based config
   const normalizedRoleFromParam = normalizeManageBillsRoleParam(role);
@@ -245,7 +248,7 @@ const ManageBills = () => {
     url: `/${expenseContextPath}/bill/v1/report/_search`,
   });
 
-  const triggerBulkUpdateBills = async (bills, action) => {
+  const triggerBulkUpdateBills = async (bills, action, signature = null) => {
     try {
       await bulkUpdateMutation.mutateAsync(
         {
@@ -259,6 +262,7 @@ const ManageBills = () => {
               comments: `Bulk ${action} triggered`,
               assignes: [],
             },
+            ...(signature ? { signature } : {}),
           },
         },
         {
@@ -725,11 +729,29 @@ const ManageBills = () => {
               if (!selectedBills?.length) return;
               const action = activePopUpAction;
               setActivePopUpAction(null);
+              if (["SEND_FOR_REVIEW", "SEND_FOR_APPROVAL"].includes(action)) {
+                setSignatureFlow({ action, count: selectedBills.length });
+                return;
+              }
               await triggerBulkUpdateBills(selectedBills, action);
             }}
           />
         );
       })()}
+
+      {signatureFlow && (
+        <SignaturePopUp
+          heading={t(`HCM_AM_SIGNATURE_POPUP_HEADING_${signatureFlow.action}`)}
+          description={t("HCM_AM_SIGNATURE_POPUP_BULK_DESCRIPTION", { count: signatureFlow.count })}
+          submitLabel={t(`HCM_AM_${signatureFlow.action}`)}
+          onClose={() => setSignatureFlow(null)}
+          onSubmit={async (signature) => {
+            const { action } = signatureFlow;
+            setSignatureFlow(null);
+            await triggerBulkUpdateBills(selectedBills, action, signature);
+          }}
+        />
+      )}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
**Feature/Bugfix Request**
JIRA ID
HDDF-5439

**Module**
Health Payments (Payment Module - Bill Approval)

**Description**
Implemented a new approval step to capture approver signature details before bill approval is finalized.

**Changes include:**

- Added a pre-approval signature capture dialog when user clicks Approve.
- Added mandatory Printed Name field with whitespace validation.
- Added Signature Method selection with two options:
            - Draw Signature (canvas with clear/redraw support)
            - Upload Signature (PNG/JPG/JPEG, max 5 MB)
- Blocked approval submission unless both Printed Name and valid signature are provided.
- Persisted approval metadata with the bill approval record:
            - Printed Name
            - Signature image
            - Approving user
            - Approval role
            - Approval timestamp
            - Approval status
- Updated approval detail surfaces (history/details/printable contexts) to display:
            - Printed Name
            - Signature
            - Role
            - Approval Date and Time
            - Approval Status
  - Extended audit trail to include printed name and signature used during approval.