### PR TITLE
FEATURE/HCMPRE-999 : Use .env for global config and proxy URL

### DIFF
--- a/health/micro-ui-react19/web/builds/core-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/core-ui/public/index.html
@@ -15,10 +15,7 @@
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>
   <script src="https://unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
-  <!-- <script src="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/globalConfigsWorkbenchDev.js"></script> -->
-
-
-  <script src="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/globalConfigsWorkbenchHCMMZ.js"></script>
+  <script src="<%= REACT_APP_GLOBAL %>"></script>
 
 </head>
 

--- a/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
+++ b/health/micro-ui-react19/web/builds/workbench-ui/public/index.html
@@ -15,10 +15,7 @@
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>
   <script src="https://unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
-  <!-- <script src="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/globalConfigsWorkbenchDev.js"></script> -->
-
-
-
+  <script src="<%= REACT_APP_GLOBAL %>"></script>
 </head>
 
 <body>

--- a/health/micro-ui-react19/web/public/index.html
+++ b/health/micro-ui-react19/web/public/index.html
@@ -15,10 +15,7 @@
   <meta name="theme-color" content="#00bcd1" />
   <title>DIGIT HCM</title>
   <script src="https://unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
-  <!-- <script src="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/globalConfigsWorkbenchDev.js"></script> -->
-
-
-  <script src="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/globalConfigsWorkbenchDev.js"></script>
+  <script src="<%= REACT_APP_GLOBAL %>"></script>
   <script>
     if (navigator.platform.indexOf('Mac') !== -1) {
       document.documentElement.style.fontSize = '14.4px';

--- a/health/micro-ui-react19/web/webpack.dev.js
+++ b/health/micro-ui-react19/web/webpack.dev.js
@@ -117,7 +117,7 @@ module.exports = merge(common, {
           "/census-service",
           "/airflow-trigger-api"
         ],
-        target: process.env.REACT_APP_PROXY_URL || "https://unified-uat.digit.org",
+        target: process.env.REACT_APP_PROXY_API || "https://unified-dev.digit.org",
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary
- Replaced hardcoded global config script URLs in all three `index.html` files (`public/`, `builds/core-ui/public/`, `builds/workbench-ui/public/`) with EJS template variable `<%= REACT_APP_GLOBAL %>`, injected by HtmlWebpackPlugin from `.env`
- Fixed `webpack.dev.js` proxy target to read `REACT_APP_PROXY_API` from `.env` instead of the non-existent `REACT_APP_PROXY_URL` variable

## Why
Switching environments (BEDNETHCM, HCMDEMO, DEV, UAT, etc.) previously required manually editing 3 index.html files and the webpack proxy URL. Now only the `.env` file needs to be changed — `REACT_APP_GLOBAL` and `REACT_APP_PROXY_API` drive everything automatically on `yarn start`.

## Test plan
- [ ] Switch `.env` to different environments (e.g. BEDNETHCM, HCMDEMO, DEV) and run `yarn start` — verify the correct global config script loads in the browser
- [ ] Verify API proxy routes to the correct backend from `.env`
- [ ] Verify production builds (`yarn build`) pick up `REACT_APP_GLOBAL` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Global configuration scripts can now be selected through the application environment, supporting more flexible deployments.
  * Development proxy requests now use the configured API endpoint, with an updated default development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->