### PR TITLE
BUGFIX/HCMPRE-4177 : Fix boundary loading toast blocking and persistence polling edge cases

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/BoundarySummary.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/BoundarySummary.js
@@ -120,8 +120,11 @@ const BoundarySummary = (props) => {
 
     if (!isPersisted) {
       if (retryCountRef.current < MAX_PERSISTENCE_RETRIES) {
+        // Don't start another timer if one is already running
+        if (retryTimerRef.current) return;
         setIsPolling(true);
         retryTimerRef.current = setTimeout(() => {
+          retryTimerRef.current = null;
           retryCountRef.current += 1;
           refetch();
         }, PERSISTENCE_RETRY_DELAY_MS);
@@ -134,11 +137,17 @@ const BoundarySummary = (props) => {
       setIsPolling(false);
       Digit.SessionStorage.del("campaignBoundaryFingerprint");
     }
-
-    return () => {
-      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
-    };
   }, [isLoading, isFetching, data]);
+
+  // Cleanup polling timer on unmount only
+  useEffect(() => {
+    return () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const closeToast = () => {
     setShowToast(null);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/DeliveryDetailsSummary.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/DeliveryDetailsSummary.js
@@ -372,8 +372,11 @@ const DeliveryDetailsSummary = (props) => {
     const isPersisted = serverFingerprint === expectedFingerprint;
     if (!isPersisted) {
       if (retryCountRef.current < MAX_PERSISTENCE_RETRIES) {
+        // Don't start another timer if one is already running
+        if (retryTimerRef.current) return;
         setIsPolling(true);
         retryTimerRef.current = setTimeout(() => {
+          retryTimerRef.current = null;
           retryCountRef.current += 1;
           refetch();
         }, PERSISTENCE_RETRY_DELAY_MS);
@@ -387,12 +390,17 @@ const DeliveryDetailsSummary = (props) => {
       setIsPolling(false);
       Digit.SessionStorage.del("campaignDeliveryFingerprint");
     }
+  }, [isLoading, isFetching, data]);
+
+  // Cleanup polling timer on unmount only
+  useEffect(() => {
     return () => {
       if (retryTimerRef.current) {
         clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
       }
     };
-  }, [isLoading, isFetching, data]);
+  }, []);
 
   const closeToast = () => {
     setShowToast(null);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -42,7 +42,14 @@ const CreateCampaign = () => {
 
   const prevProjectTypeRef = useRef();
   const hasLoadedDraft = useRef(false);
+  const pendingHierarchySubmitRef = useRef(null);
   const queryClient = useQueryClient();
+
+  // Live boundary loading state for the selected hierarchy — shares React Query cache with SelectHierarchy
+  const { data: boundaryDataForHierarchy, isLoading: isBoundaryLoadingDirect } = Digit.Hooks.campaign.useBoundaryRelationshipSearch({
+    BOUNDARY_HIERARCHY_TYPE: storedHierarchy?.name,
+    tenantId,
+  });
 
   const updateUrlParams = (params) => {
     const url = new URL(window.location.href);
@@ -63,6 +70,25 @@ const CreateCampaign = () => {
   const closeToast = () => {
     setShowToast(null);
   };
+
+  // Auto-proceed when boundary finishes loading after a pending hierarchy submit
+  useEffect(() => {
+    if (!pendingHierarchySubmitRef.current || isBoundaryLoadingDirect) return;
+    const pendingData = pendingHierarchySubmitRef.current;
+    pendingHierarchySubmitRef.current = null;
+    setShowToast(null);
+    // Boundary loaded — check if data exists and proceed
+    const hasBoundaryData = !!(boundaryDataForHierarchy && boundaryDataForHierarchy.length > 0);
+    const isEditMode = !!(editName || campaignNumber || id);
+    const originalHierarchyName = params?.hierarchyType || params?.SelectHierarchy?.hierarchy?.name;
+    const currentHierarchyName = storedHierarchy?.name;
+    const isSameHierarchyAsOriginal = isEditMode && !!originalHierarchyName && !!currentHierarchyName && originalHierarchyName === currentHierarchyName;
+    if (!hasBoundaryData && !isSameHierarchyAsOriginal) {
+      setShowToast({ key: "error", label: t(I18N_KEYS.PAGES.HCM_NO_BOUNDARY_DATA_FOR_HIERARCHY) });
+      return;
+    }
+    handleCampaignMutation(pendingData);
+  }, [isBoundaryLoadingDirect]);
 
   const onSecondayActionClick = () => {
   if (currentKey > 1) {
@@ -521,12 +547,15 @@ const CreateCampaign = () => {
         setShowToast({ key: "error", label: t(I18N_KEYS.PAGES.HCM_SELECT_HIERARCHY_REQUIRED) });
         return;
       }
-      const isBoundaryLoading = formData?.SelectHierarchy?.isBoundaryLoading ?? params?.SelectHierarchy?.isBoundaryLoading;
-      if (isBoundaryLoading) {
+      // Use live loading state from the hook instead of stale form data snapshot
+      if (isBoundaryLoadingDirect) {
         setShowToast({ key: "info", label: t(I18N_KEYS.PAGES.HCM_BOUNDARY_DATA_LOADING) });
+        // Store pending submit so we auto-proceed when boundary finishes loading
+        pendingHierarchySubmitRef.current = formData;
         return;
       }
-      const hasBoundaryData = formData?.SelectHierarchy?.hasBoundaryData ?? params?.SelectHierarchy?.hasBoundaryData;
+      pendingHierarchySubmitRef.current = null;
+      const hasBoundaryData = !!(boundaryDataForHierarchy && boundaryDataForHierarchy.length > 0);
       const isEditMode = !!(editName || campaignNumber || id);
       const originalHierarchyName = params?.hierarchyType || params?.SelectHierarchy?.hierarchy?.name;
       const currentHierarchyName = hierarchySelected?.name;

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -92,6 +92,8 @@ const CreateCampaign = () => {
 
   const onSecondayActionClick = () => {
   if (currentKey > 1) {
+    // Invalidate any pending hierarchy submit so stale data isn't auto-submitted
+    pendingHierarchySubmitRef.current = null;
     // Clear campaign name when going back to step 1 (only for new campaigns, not edit/clone)
     if (currentKey === 2 && !editName && !campaignNumber) {
       setParams((prev) => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -1112,6 +1112,8 @@ const SetupCampaign = () => {
 
   const onSecondayActionClick = () => {
     if (currentKey > 1) {
+      // Invalidate any pending update so stale data isn't auto-submitted
+      pendingUpdateRef.current = false;
       setShouldUpdate(false);
       setCurrentKey(currentKey - 1);
       setSummaryErrors(null);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -1,5 +1,5 @@
 import { FormComposerV2 } from "@egovernments/digit-ui-react-components";
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { CampaignConfig } from "../../configs/CampaignConfig";
@@ -105,6 +105,7 @@ const SetupCampaign = () => {
   const [fetchBoundary, setFetchBoundary] = useState(() => Boolean(searchParams.get("fetchBoundary")));
   const [fetchUpload, setFetchUpload] = useState(false);
   const [active, setActive] = useState(0);
+  const pendingUpdateRef = useRef(false);
   const { data: HierarchySchema } = Digit.Hooks.useCustomMDMS(
     tenantId,
     CONSOLE_MDMS_MODULENAME,
@@ -292,11 +293,14 @@ const SetupCampaign = () => {
   useEffect(() => {
     async function handleUpdate() {
       if (shouldUpdate === true) {
-        // Wait for boundary search to finish before validating
+        // Wait for boundary search to finish — show toast and defer update
         if (isBoundaryLoading) {
+          setShowToast({ key: "info", label: t(I18N_KEYS.PAGES.HCM_BOUNDARY_DATA_LOADING) });
+          pendingUpdateRef.current = true;
           setShouldUpdate(false);
           return;
         }
+        pendingUpdateRef.current = false;
         // Block campaign create/update if no boundary data exists for the selected hierarchy type
         if (hierarchyType && (!hierarchyData || hierarchyData.length === 0)) {
           setShowToast({ key: "error", label: t(I18N_KEYS.PAGES.HCM_NO_BOUNDARY_DATA_FOR_HIERARCHY) });
@@ -638,6 +642,14 @@ const SetupCampaign = () => {
     }
     handleUpdate();
   }, [shouldUpdate]);
+
+  // Auto-retry update when boundary finishes loading after a pending submit
+  useEffect(() => {
+    if (!pendingUpdateRef.current || isBoundaryLoading) return;
+    pendingUpdateRef.current = false;
+    setShowToast(null);
+    setShouldUpdate(true);
+  }, [isBoundaryLoading]);
 
   useEffect(() => {
     if (showToast) {


### PR DESCRIPTION
## Summary

- **CreateCampaign.js**: Fixed hierarchy submit toast blocking by using a live `useBoundaryRelationshipSearch` hook instead of stale form data snapshot. Added auto-proceed mechanism via `pendingHierarchySubmitRef` that automatically continues campaign creation when boundary data finishes loading.
- **SetupCampaign.js**: Fixed silent submit cancel when boundary is loading — now shows an info toast and auto-retries the update when boundary loading completes, instead of silently discarding the user's submit action.
- **BoundarySummary.js / DeliveryDetailsSummary.js**: Fixed persistence polling timers getting cancelled prematurely. The `useEffect` cleanup was clearing retry timers on every re-render (triggered by `isFetching` toggling with `staleTime: 0`). Now uses a guard to prevent duplicate timers, clears the ref inside the callback after firing, and moves cleanup to a separate unmount-only effect.

## Test plan

- [ ] Submit hierarchy type selection while boundary API is in-flight — verify info toast appears and campaign creation proceeds automatically once boundary data loads
- [ ] Submit hierarchy type in SetupCampaign (edit flow) while boundary is loading — verify toast appears and update retries automatically
- [ ] Verify boundary persistence polling (3 retries at 5s intervals) fires reliably on BoundarySummary page after saving boundary changes
- [ ] Verify delivery persistence polling fires reliably on DeliveryDetailsSummary page after saving delivery rule changes
- [ ] Verify no duplicate polling timers or infinite loops when pages re-render during polling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate background checks while campaign boundary and delivery-rule data are being verified.
  - Improved cleanup of background checks when summary components are closed.
  - Campaign creation and updates now wait for required boundary data to finish loading instead of failing or being blocked.
  - Pending submissions and updates automatically resume once the required data becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->