### PR TITLE
FEATURE/HCMPRE-8282 : Fix Select All reset on parent clear and hierarchy API caching

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useState, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { I18N_KEYS } from "../utils/i18nKeyConstants";
 import { Tag, Button, Card, SummaryCardFieldPair, Divider, PopUp, CardText, Chip } from "@egovernments/digit-ui-components";
@@ -82,7 +82,7 @@ const getTagElements = (rowData) => {
 };
 
 // function to handle download user creds
-const handleDownloadUserCreds = async (campaignId, hierarchyType) => {
+const handleDownloadUserCreds = async (campaignId, hierarchyType, campaignNumber) => {
   try {
     const tenantId = Digit.ULBService.getCurrentTenantId();
     const responseTemp = await Digit.CustomService.getResponse({
@@ -100,7 +100,7 @@ const handleDownloadUserCreds = async (campaignId, hierarchyType) => {
     if (response?.[0]) {
       downloadExcelWithCustomName({
         fileStoreId: response[0],
-        customName: "userCredential",
+        customName: campaignNumber ? `${campaignNumber}-Users` : "userCredential",
       });
     } else {
       console.error("No file store ID found for user credentials");
@@ -119,6 +119,7 @@ const getActionButtons = (rowData, tabData, navigate, setShowErrorPopUp, setShow
   //     : null;
   const campaignId = rowData?.id;
   const hierarchyType = rowData?.hierarchyType;
+  const campaignNumber = rowData?.campaignNumber;
 
   // Always show download if userCreds exist
   if (rowData?.status == "created") {
@@ -134,7 +135,7 @@ const getActionButtons = (rowData, tabData, navigate, setShowErrorPopUp, setShow
     actions.downloadUserCreds = {
       label: "DOWNLOAD_USER_CREDENTIALS",
       title: "DOWNLOAD_USER_CREDENTIALS",
-      onClick: () => handleDownloadUserCreds(campaignId, hierarchyType),
+      onClick: () => handleDownloadUserCreds(campaignId, hierarchyType, campaignNumber),
       icon: "FileDownload",
       size: "medium",
       id:`my-campaigns-row-card-download-user-creds-button-${campaignId}`,
@@ -199,32 +200,6 @@ const getActionButtons = (rowData, tabData, navigate, setShowErrorPopUp, setShow
   return actions;
 };
 
-const getActionTags = (rowData) => {
-  const actions = {};
-
-  if (rowData?.status == "creating") {
-    actions.generateUserCreds = {
-      label: "GENERATING_USER_CRED",
-      loader: true,
-      showBottom: true,
-      animationStyle: {
-        width: "2rem",
-        height: "2rem",
-      },
-    };
-    actions.generateAPK = {
-      label: "GENERATING_APK",
-      loader: true,
-      showBottom: true,
-      animationStyle: {
-        width: "2rem",
-        height: "2rem",
-      },
-    };
-  }
-
-  return actions;
-};
 
 const reqUpdate = {
   url: `/project-factory/v1/project-type/update`,
@@ -240,6 +215,49 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
   const navigate = useNavigate();
   const [showRetryPopUp, setShowRetryPopUp] = useState(false);
   const mutationUpdate = Digit.Hooks.useCustomAPIMutationHook(reqUpdate);
+
+  const isCreating = rowData?.status === "creating";
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+  const statusReqCriteria = useMemo(() => ({
+    url: `/project-factory/v1/project-type/status`,
+    params: {},
+    body: {
+      CampaignDetails: {
+        campaignNumber: rowData?.campaignNumber,
+        tenantId: tenantId,
+      },
+    },
+    config: {
+      enabled: isCreating,
+      refetchInterval: isCreating ? 25000 : false,
+    },
+    changeQueryName: `campaignStatus_${rowData?.campaignNumber}`,
+  }), [rowData?.campaignNumber, tenantId, isCreating]);
+
+  const { data: statusData, isLoading: isStatusLoading } = Digit.Hooks.useCustomAPIHook(statusReqCriteria);
+
+  // Refresh the page when all processes are completed so the table shows updated campaign status
+  // Uses sessionStorage to prevent infinite reload if backend status hasn't transitioned yet
+  useEffect(() => {
+    const refreshKey = `campaignStatusRefresh_${rowData?.campaignNumber}`;
+    if (!isCreating) {
+      // Campaign is no longer "creating" — clean up the sessionStorage entry
+      sessionStorage.removeItem(refreshKey);
+      return;
+    }
+    if (isStatusLoading) return;
+    const processes = statusData?.CampaignStatus?.processes;
+    if (Array.isArray(processes) && processes.length > 0) {
+      const allCompleted = processes.every((p) => p?.status === "completed" || p?.status === "failed");
+      if (allCompleted) {
+        const lastRefresh = sessionStorage.getItem(refreshKey);
+        if (lastRefresh && Date.now() - Number(lastRefresh) < 60000) return;
+        sessionStorage.setItem(refreshKey, String(Date.now()));
+        window.location.href = `/${window?.contextPath}/employee/campaign/my-campaign-new`;
+      }
+    }
+  }, [statusData, isCreating, isStatusLoading, rowData?.campaignNumber]);
+
   const handleRetryLogic = async (rowData) => {
     const updatedRowData = {
       CampaignDetails: {
@@ -286,7 +304,39 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
     setShowQRPopUp,
     handleRetryLogic
   );
-  const actionTags = getActionTags(rowData);
+  const actionTags = useMemo(() => {
+    if (!isCreating) return {};
+    const processes = statusData?.CampaignStatus?.processes;
+    if (!isStatusLoading && Array.isArray(processes) && processes.length > 0) {
+      // Find the first process that is not yet completed — represents current progress
+      const currentProcess = processes.find((p) => p?.status !== "completed" && p?.status !== "failed");
+      // If all processes are done, show the last one
+      const displayProcess = currentProcess || processes[processes.length - 1];
+      const isComplete = displayProcess?.status === "completed" || displayProcess?.status === "failed";
+      return {
+        currentProcess: {
+          label: displayProcess?.processname || "CAMPAIGN_CREATION_INPROGRESS",
+          loader: !isComplete,
+          showBottom: true,
+          animationStyle: {
+            width: "2rem",
+            height: "2rem",
+          },
+        },
+      };
+    }
+    return {
+      currentProcess: {
+        label: "CAMPAIGN_CREATION_INPROGRESS",
+        loader: true,
+        showBottom: true,
+        animationStyle: {
+          width: "2rem",
+          height: "2rem",
+        },
+      },
+    };
+  }, [isCreating, statusData, isStatusLoading]);
   const tagElements = getTagElements(rowData);
   const [cloneCampaign, setCloneCampaign] = useState(false);
   const showCancelCampaign = rowData?.status === "creating" || rowData?.status === "drafted";

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/HCMMyCampaignRowCard.js
@@ -201,6 +201,8 @@ const getActionButtons = (rowData, tabData, navigate, setShowErrorPopUp, setShow
 };
 
 
+const isProcessDone = (p) => p?.status === "completed" || p?.status === "failed";
+
 const reqUpdate = {
   url: `/project-factory/v1/project-type/update`,
   params: {},
@@ -234,7 +236,7 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
     changeQueryName: `campaignStatus_${rowData?.campaignNumber}`,
   }), [rowData?.campaignNumber, tenantId, isCreating]);
 
-  const { data: statusData, isLoading: isStatusLoading } = Digit.Hooks.useCustomAPIHook(statusReqCriteria);
+  const { data: statusData, isLoading: isStatusLoading, isError: isStatusError } = Digit.Hooks.useCustomAPIHook(statusReqCriteria);
 
   // Refresh the page when all processes are completed so the table shows updated campaign status
   // Uses sessionStorage to prevent infinite reload if backend status hasn't transitioned yet
@@ -248,7 +250,7 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
     if (isStatusLoading) return;
     const processes = statusData?.CampaignStatus?.processes;
     if (Array.isArray(processes) && processes.length > 0) {
-      const allCompleted = processes.every((p) => p?.status === "completed" || p?.status === "failed");
+      const allCompleted = processes.every(isProcessDone);
       if (allCompleted) {
         const lastRefresh = sessionStorage.getItem(refreshKey);
         if (lastRefresh && Date.now() - Number(lastRefresh) < 60000) return;
@@ -306,17 +308,30 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
   );
   const actionTags = useMemo(() => {
     if (!isCreating) return {};
+    if (isStatusError) {
+      return {
+        currentProcess: {
+          label: "CAMPAIGN_STATUS_CHECK_FAILED",
+          loader: false,
+          showBottom: true,
+          type: "error",
+          animationStyle: {
+            width: "2rem",
+            height: "2rem",
+          },
+        },
+      };
+    }
     const processes = statusData?.CampaignStatus?.processes;
     if (!isStatusLoading && Array.isArray(processes) && processes.length > 0) {
       // Find the first process that is not yet completed — represents current progress
-      const currentProcess = processes.find((p) => p?.status !== "completed" && p?.status !== "failed");
+      const currentProcess = processes.find((p) => !isProcessDone(p));
       // If all processes are done, show the last one
       const displayProcess = currentProcess || processes[processes.length - 1];
-      const isComplete = displayProcess?.status === "completed" || displayProcess?.status === "failed";
       return {
         currentProcess: {
           label: displayProcess?.processname || "CAMPAIGN_CREATION_INPROGRESS",
-          loader: !isComplete,
+          loader: !isProcessDone(displayProcess),
           showBottom: true,
           animationStyle: {
             width: "2rem",
@@ -336,7 +351,7 @@ const HCMMyCampaignRowCard = ({ key, rowData, tabData }) => {
         },
       },
     };
-  }, [isCreating, statusData, isStatusLoading]);
+  }, [isCreating, statusData, isStatusLoading, isStatusError]);
   const tagElements = getTagElements(rowData);
   const [cloneCampaign, setCloneCampaign] = useState(false);
   const showCancelCampaign = rowData?.status === "creating" || rowData?.status === "drafted";

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -515,6 +515,8 @@ const MultiSelectDropdown = ({
 
   const handleClearAll = () => {
     dispatch({ type: "REPLACE_COMPLETE_STATE", payload: [] });
+    setSelectAllChecked(false);
+    setCategorySelected({});
     onSelect([], getCategorySelectAllState(), props);
     if (onClose) {
       onClose([], getCategorySelectAllState(), props);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -354,6 +354,11 @@ const MultiSelectDropdown = ({
       type: "REPLACE_COMPLETE_STATE",
       payload: fnToSelectOptionThroughProvidedSelection(selected),
     });
+    // Reset Select All and category checkboxes when selection is cleared externally (e.g., parent dropdown cleared)
+    if (!selected || selected.length === 0) {
+      setSelectAllChecked(false);
+      setCategorySelected({});
+    }
   }, [selectedSyncKey]);
 
   // useEffect(() => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -75,6 +75,10 @@ const SelectingBoundaryComponent = ({
         hierarchyType: hierarchyType,
       },
     },
+    config: {
+      cacheTime: 1000000,
+      staleTime: 600000,
+    },
   };
 
   const { isLoading: hierarchyLoading, data: hierarchy } = Digit.Hooks.useCustomAPIHook(reqCriteria);
@@ -247,29 +251,32 @@ const SelectingBoundaryComponent = ({
       return;
     }
 
-    // Wrap ALL state updates in startTransition so React can show the loader
+    // Clear case: update state immediately (no startTransition) so child dropdowns
+    // reset their Select All / category checkboxes without delay.
+    if (!data || data.length === 0) {
+      const structure = createHierarchyStructure(hierarchy);
+      const check = structure?.[boundary.boundaryType];
+
+      if (check) {
+        const typesToRemoveSet = new Set([boundary?.boundaryType, ...check]);
+        const updatedSelectedData = selectedData?.filter((item) => !typesToRemoveSet.has(item?.type));
+        const updatedBoundaryData = { ...boundaryOptions };
+        typesToRemoveSet.forEach((type) => {
+          if (type !== boundary?.boundaryType && updatedBoundaryData?.hasOwnProperty(type)) {
+            updatedBoundaryData[type] = {};
+          }
+        });
+        if (!_.isEqual(selectedData, updatedSelectedData)) {
+          setSelectedData(updatedSelectedData);
+        }
+        setBoundaryOptions(updatedBoundaryData);
+      }
+      return;
+    }
+
+    // Wrap selection state updates in startTransition so React can show the loader
     // while the heavy re-render (memoized options, downstream effects) is processed.
     startTransition(() => {
-      if (!data || data.length === 0) {
-        const structure = createHierarchyStructure(hierarchy);
-        const check = structure?.[boundary.boundaryType];
-
-        if (check) {
-          const typesToRemoveSet = new Set([boundary?.boundaryType, ...check]);
-          const updatedSelectedData = selectedData?.filter((item) => !typesToRemoveSet.has(item?.type));
-          const updatedBoundaryData = { ...boundaryOptions };
-          typesToRemoveSet.forEach((type) => {
-            if (type !== boundary?.boundaryType && updatedBoundaryData?.hasOwnProperty(type)) {
-              updatedBoundaryData[type] = {};
-            }
-          });
-          if (!_.isEqual(selectedData, updatedSelectedData)) {
-            setSelectedData(updatedSelectedData);
-          }
-          setBoundaryOptions(updatedBoundaryData);
-        }
-        return;
-      }
 
       let res = isMultiSelect ? data?.map((ob) => ob?.[1]) || [] : [data];
       let transformedRes = [];

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CampaignDetails.js
@@ -197,6 +197,7 @@ const CampaignDetails = () => {
   const retryTimerRef = useRef(null);
   const afterUpload = location.state?.afterUpload;
   const [isPolling, setIsPolling] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (!afterUpload) return;
@@ -661,12 +662,14 @@ const CampaignDetails = () => {
   };
 
   const onsubmit = async () => {
+    if (isSubmitting) return;
     const valideDates = validateCampaignDates(campaignData?.deliveryRules?.[0]?.cycles, campaignData);
     if (!valideDates) {
       setShowToast({ key: "error", label: "INVALID_DATES" });
       return;
     }
-    await mutationUpdate.mutate(
+    setIsSubmitting(true);
+    mutationUpdate.mutate(
       {
         url: `/project-factory/v1/project-type/update`,
         body: transformUpdateCreateData({ campaignData }),
@@ -695,6 +698,7 @@ const CampaignDetails = () => {
           );
         },
         onError: (error, result) => {
+          setIsSubmitting(false);
           const errorCode = error?.response?.data?.Errors?.[0]?.code;
           setShowToast({ key: "error", label: errorCode ? t(errorCode) : t(I18N_KEYS.CAMPAIGN_CREATE.ERROR_CREATE_CAMPAIGN) });
         },
@@ -738,6 +742,8 @@ const CampaignDetails = () => {
     return <Loader page={true} variant={"PageLoader"} />;
   }
 
+  const isMutationLoading = isSubmitting;
+
   const week = `${convertEpochToNewDateFormat(campaignData?.startDate)} - ${convertEpochToNewDateFormat(campaignData?.endDate)}`;
 
   const closeToast = () => {
@@ -746,6 +752,7 @@ const CampaignDetails = () => {
 
   return (
     <>
+      {isMutationLoading && <Loader page={true} variant={"OverlayLoader"} loaderText={t(I18N_KEYS.COMPONENTS.HCM_CAMPAIGN_CREATION_PROGRESS)}/>}
       <div className="campaign-details-header">
         <div style={{ display: "flex", alignItems: "baseline", gap: "1rem" }}>
           <HeaderComponent className={"date-header"}>{campaignData?.campaignName}</HeaderComponent>
@@ -828,6 +835,7 @@ const CampaignDetails = () => {
                   title={t(I18N_KEYS.CAMPAIGN_CREATE.HCM_CREATE_CAMPAIGN)}
                   onClick={onsubmit}
                   isDisabled={
+                    isMutationLoading ||
                     campaignData?.boundaries?.length === 0 ||
                     campaignData?.deliveryRules?.length === 0 ||
                     campaignData?.deliveryRules?.some((rule) => rule?.cycles?.length === 0) ||

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -613,14 +613,16 @@ const SetupCampaign = () => {
               setIsUpdating(true);
               await updateCampaign(payloadData, {
                 onError: (error, variables) => {
-                  if (filteredConfig?.[0]?.form?.[0]?.body?.[0]?.mandatoryOnAPI) {
+                  if (filteredConfig?.[0]?.form?.[0]?.isLast || filteredConfig?.[0]?.form?.[0]?.body?.[0]?.mandatoryOnAPI) {
                     setShowToast({ key: "error", label: error?.message ? error?.message : error });
                   }
                 },
                 onSuccess: async (data) => {
                   updateUrlParams({ id: data?.CampaignDetails?.id });
                   draftRefetch();
-                  if (filteredConfig?.[0]?.form?.[0]?.body?.[0]?.mandatoryOnAPI) {
+                  if (filteredConfig?.[0]?.form?.[0]?.isLast) {
+                    setCurrentKey(currentKey + 1);
+                  } else if (filteredConfig?.[0]?.form?.[0]?.body?.[0]?.mandatoryOnAPI) {
                     setCurrentKey(currentKey + 1);
                   }
                 },
@@ -1224,7 +1226,7 @@ const SetupCampaign = () => {
             body: config?.body.filter((a) => !a.hideInEmployee),
           };
         })}
-        isDisabled={isDataCreating}
+        isDisabled={isDataCreating || isUpdating}
         onSubmit={onSubmit}
         showSecondaryLabel={currentKey > 1 ? true : false}
         secondaryLabel={isChangeDates === "true" && currentKey == 6 ? t(I18N_KEYS.COMMON.HCM_BACK) : noAction === "false" ? null : t(I18N_KEYS.COMMON.HCM_BACK)}


### PR DESCRIPTION
## Summary
- **Fix Select All not resetting on parent dropdown clear**: When a parent boundary dropdown is cleared, child dropdowns now immediately reset their Select All and per-category checkboxes. Two fixes applied:
  - In `MultiSelectDropdown.js`: Explicitly reset `selectAllChecked` and `categorySelected` when `selected` prop becomes empty
  - In `SelectingBoundaryComponent.js`: Moved the clear logic out of `startTransition` so child state updates propagate immediately instead of being deferred
- **Add hierarchy API caching**: Added `cacheTime` (1000s) and `staleTime` (600s) to the `boundary-hierarchy-definition/_search` API call to prevent redundant fetches that block the page

## Test plan
- [ ] Select boundaries at all levels, then click Clear All on the first (root) dropdown
- [ ] Open the second dropdown — confirm Select All checkbox is unchecked
- [ ] Confirm all child dropdown selections are cleared
- [ ] Re-select in the first dropdown, open child dropdowns — confirm Select All is unchecked (no stale state)
- [ ] Navigate to Edit Boundaries page — confirm hierarchy API is served from cache without blocking the page
- [ ] Confirm boundary selection still works correctly for new selections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign progress now displays the current processing status and automatically returns to the campaigns list when processing finishes.
  * Downloaded user credentials now use the campaign number in the filename.

* **Bug Fixes**
  * Clearing selections now consistently resets related checkboxes and filters.
  * Campaign submission controls are disabled during updates to prevent duplicate actions.
  * Campaign setup navigation and error handling now work correctly across final and required steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->