### PR TITLE
BUGFIX/HCMPRE-8282 : Fix boundary selection page performance, dropdown rendering, and Select All reset

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -346,12 +346,19 @@ const MultiSelectDropdown = ({
     }
   }
 
-  // Lightweight key: length + bookend codes avoids joining 16k+ codes into a huge string.
-  // Boundary selections change in bulk (clear all, select group, etc.) so
-  // length + first/last codes catch all real changes.
+  // Lightweight rolling checksum over all codes: O(n) without building a huge
+  // joined string, and unlike length + bookends it detects mid-list replacements.
   const selectedSyncKey = useMemo(() => {
     if (!selected || selected.length === 0) return "";
-    return `${selected.length}|${selected[0]?.code}|${selected[selected.length - 1]?.code}`;
+    let hash = 0;
+    for (let i = 0; i < selected.length; i++) {
+      const code = selected[i]?.code || "";
+      for (let j = 0; j < code.length; j++) {
+        hash = (hash * 31 + code.charCodeAt(j)) | 0;
+      }
+      hash = (hash * 31 + i) | 0;
+    }
+    return `${selected.length}|${hash}`;
   }, [selected]);
 
   useEffect(() => {
@@ -774,8 +781,9 @@ const MultiSelectDropdown = ({
           }
         }
       } else {
-        // Create a shallow copy to avoid mutating the original option
-        const copy = option.options ? { ...option, options: [...option.options] } : option;
+        // Always shallow copy to avoid mutating the caller's memoized option objects.
+        // Without this, a later duplicate merge (push onto existing.options) would mutate the original.
+        const copy = { ...option, options: option.options ? [...option.options] : [] };
         seenCodes.set(option?.code, copy);
         flattened.push(copy);
       }

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -354,6 +354,11 @@ const MultiSelectDropdown = ({
       type: "REPLACE_COMPLETE_STATE",
       payload: fnToSelectOptionThroughProvidedSelection(selected),
     });
+    // Reset Select All and category checkboxes when selection is cleared externally (e.g., parent dropdown cleared)
+    if (!selected || selected.length === 0) {
+      setSelectAllChecked(false);
+      setCategorySelected({});
+    }
   }, [selectedSyncKey]);
 
   // useEffect(() => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -346,13 +346,22 @@ const MultiSelectDropdown = ({
     }
   }
 
-  // Use a content-based key so the sync fires when selected items change, not just count
-  const selectedSyncKey = useMemo(() => selected?.map((s) => s?.code).join(",") ?? "", [selected]);
+  // Lightweight key: length + bookend codes avoids joining 16k+ codes into a huge string.
+  // Boundary selections change in bulk (clear all, select group, etc.) so
+  // length + first/last codes catch all real changes.
+  const selectedSyncKey = useMemo(() => {
+    if (!selected || selected.length === 0) return "";
+    return `${selected.length}|${selected[0]?.code}|${selected[selected.length - 1]?.code}`;
+  }, [selected]);
 
   useEffect(() => {
-    dispatch({
-      type: "REPLACE_COMPLETE_STATE",
-      payload: fnToSelectOptionThroughProvidedSelection(selected),
+    // Use React.startTransition so the heavy dispatch (16k+ items in boundary dropdowns)
+    // doesn't block user interactions like Clear All clicks.
+    React.startTransition(() => {
+      dispatch({
+        type: "REPLACE_COMPLETE_STATE",
+        payload: fnToSelectOptionThroughProvidedSelection(selected),
+      });
     });
     // Reset Select All and category checkboxes when selection is cleared externally (e.g., parent dropdown cleared)
     if (!selected || selected.length === 0) {
@@ -411,32 +420,39 @@ const MultiSelectDropdown = ({
     return false;
   }, [selectedCodesSet]);
 
+  // Inline selection check to avoid stale closure from useCallback checkSelection.
+  // This ensures the effect always reads the current render's selectedCodesSet directly.
+  // Wrapped in React.startTransition so the heavy iteration (16k+ boundary items) doesn't
+  // block user interactions.
   useEffect(() => {
-    const allOptionsSelected =
-      variant === "nestedmultiselect" ? checkSelection(flattenedOptions.filter((option) => !option.options)) : checkSelection(options);
+    React.startTransition(() => {
+      const inlineCheck = (items) => items && items.length > 0 ? items.every((o) => selectedCodesSet.has(o.code)) : false;
+      const leafOptions = variant === "nestedmultiselect" ? flattenedOptions.filter((option) => !option.options) : options;
+      const allOptionsSelected = inlineCheck(leafOptions);
 
-    setSelectAllChecked(allOptionsSelected);
+      setSelectAllChecked(allOptionsSelected);
 
-    const query = deferredSearchQuery?.toLowerCase();
-    const newCategorySelected = {};
-    options
-      .filter((option) => option.options)
-      .forEach((category) => {
-        let filteredCategoryOptions = category.options;
+      const query = deferredSearchQuery?.toLowerCase();
+      const newCategorySelected = {};
+      options
+        .filter((option) => option.options)
+        .forEach((category) => {
+          let filteredCategoryOptions = category.options;
 
-        if (query?.length > 0) {
-          filteredCategoryOptions = category.options.filter((option) =>
-            t(option?.code)?.toLowerCase()?.includes(query)
-          );
-        }
+          if (query?.length > 0) {
+            filteredCategoryOptions = category.options.filter((option) =>
+              t(option?.code)?.toLowerCase()?.includes(query)
+            );
+          }
 
-        if (filteredCategoryOptions?.length > 0) {
-          newCategorySelected[category.code] = checkSelection(filteredCategoryOptions);
-        }
-      });
+          if (filteredCategoryOptions?.length > 0) {
+            newCategorySelected[category.code] = inlineCheck(filteredCategoryOptions);
+          }
+        });
 
-    setCategorySelected(newCategorySelected);
-  }, [options, selectedCodesSet, deferredSearchQuery, checkSelection, flattenedOptions, variant, t]);
+      setCategorySelected(newCategorySelected);
+    });
+  }, [options, selectedCodesSet, deferredSearchQuery, flattenedOptions, variant, t]);
 
   function handleOutsideClickAndSubmitSimultaneously() {
     setActive(false);
@@ -749,9 +765,13 @@ const MultiSelectDropdown = ({
       const existing = seenCodes.get(option?.code);
 
       if (existing) {
-        // If the code already exists, merge the new options into the copy
+        // Merge children via push instead of concat to avoid O(n²) array copying.
+        // concat copies the entire accumulated array on each call; push is O(1) amortized.
         if (option.options) {
-          existing.options = (existing.options || []).concat(option.options);
+          if (!existing.options) existing.options = [];
+          for (let k = 0; k < option.options.length; k++) {
+            existing.options.push(option.options[k]);
+          }
         }
       } else {
         // Create a shallow copy to avoid mutating the original option
@@ -891,8 +911,8 @@ const MultiSelectDropdown = ({
       );
     }
 
-    // Add 2px buffer to prevent sub-pixel scrollbar when items exactly fill the container
-    const listHeight = Math.min(optionsToRender.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT + 2;
+    // Add 2px buffer when there's only one option to prevent a sub-pixel scrollbar
+    const listHeight = Math.min(optionsToRender.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT + (optionsToRender.length === 1 ? 2 : 0);
 
     const VirtualizedRow = ({ index, style }) => {
       const option = optionsToRender[index];
@@ -930,7 +950,7 @@ const MultiSelectDropdown = ({
           itemSize={ITEM_HEIGHT}
           width="100%"
           overscanCount={OVERSCAN_COUNT}
-          style={{ overflowX: "hidden" }}
+          style={optionsToRender.length === 1 ? { overflowX: "hidden" } : undefined}
         >
           {VirtualizedRow}
         </List>
@@ -1000,7 +1020,7 @@ const MultiSelectDropdown = ({
           </div>
         </div>
         {active ? (
-          <div className="digit-multiselectdropdown-server" id="jk-dropdown-unique" style={ServerStyle ? ServerStyle : {}}>
+          <div className="digit-multiselectdropdown-server" id="jk-dropdown-unique" style={{ overflow: "visible", maxHeight: "none", ...(ServerStyle || {}) }}>
             {variant === "treemultiselect" ? (
               <TreeSelect
                 options={parentOptionsWithChildren}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, Fragment, useEffect, useCallback } from "react";
+import React, { useState, useMemo, useRef, Fragment, useEffect, useCallback, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Wrapper } from "./SelectingBoundaryComponent";
@@ -64,7 +64,7 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
     () => (hierarchyType ? [`boundary-${hierarchyType}`] : []),
     [hierarchyType]
   );
-  Digit.Services.useStore({
+  const { isLoading: isLocalizationLoading } = Digit.Services.useStore({
     stateCode,
     moduleCode: boundaryModuleCode,
     language,
@@ -94,6 +94,9 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
   const [executionCount, setExecutionCount] = useState(0);
   const [currentStep, setCurrentStep] = useState(2);
   const [isLoading, setIsLoading] = useState(true);
+  // useTransition keeps the loader visible while React renders the heavy component tree
+  // (SelectingBoundaryComponent with 16k+ boundary items) in the background.
+  const [isMountPending, startMountTransition] = useTransition();
   const [showPopUp, setShowPopUp] = useState(false);
   const currentKey = searchParams.get("key");
   const [key, setKey] = useState(() => {
@@ -113,7 +116,10 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
   //   setCurrentStep(currentKey);
   // }, [currentKey]);
 
-  const reqCriteria = {
+  // Only fetch campaign data when session data is NOT available (first visit to boundary step).
+  // When session data exists (user navigated back), boundaries are already in session — skip the API call.
+  const hasSessionData = !!sessionData;
+  const reqCriteria = useMemo(() => ({
     url: `/project-factory/v1/project-type/search`,
     body: {
       CampaignDetails: {
@@ -122,12 +128,14 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
       },
     },
     config: {
-      enabled: !!campaignNumber,
+      enabled: !!campaignNumber && !hasSessionData,
       select: (data) => {
         return data?.CampaignDetails?.[0];
       },
+      cacheTime: 1000000,
+      staleTime: 600000,
     },
-  };
+  }), [tenantId, campaignNumber, hasSessionData]);
 
   const { data: campaignData, isFetching } = Digit.Hooks.useCustomAPIHook(reqCriteria);
 
@@ -161,12 +169,11 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
     if (!isDataLoaded) {
       setIsDataLoaded(true);
     }
-    // Yield to browser so the loader can paint before heavy child components mount.
-    // Use double-rAF to guarantee the loader frame is actually rendered.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setIsLoading(false);
-      });
+    // Use startTransition so React keeps the loader visible while it renders
+    // the heavy SelectingBoundaryComponent tree (16k+ items) in the background.
+    // Unlike rAF, this actually prevents the UI from freezing during computation.
+    startMountTransition(() => {
+      setIsLoading(false);
     });
   }, [isFetching, campaignNumber]);
 
@@ -289,8 +296,11 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
   };
 
   const isBoundaryDataLoading = !!hierarchyType && props?.props?.hierarchyData === undefined;
+  // Wait for boundary localizations to load so dropdown labels render correctly.
+  // Only check when localization is actually needed (hierarchyType is known).
+  const isLocalizationPending = boundaryModuleCode.length > 0 && isLocalizationLoading;
 
-  if (isLoading || isBoundaryDataLoading) {
+  if (isLoading || isMountPending || isBoundaryDataLoading || isLocalizationPending) {
     return <Loader page={true} variant={"PageLoader"} />;
   }
 

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundariesDuplicate.js
@@ -132,7 +132,7 @@ const SelectingBoundariesDuplicate = ({ onSelect, formData, ...props }) => {
       select: (data) => {
         return data?.CampaignDetails?.[0];
       },
-      cacheTime: 1000000,
+      gcTime: 1000000,
       staleTime: 600000,
     },
   }), [tenantId, campaignNumber, hasSessionData]);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -75,6 +75,10 @@ const SelectingBoundaryComponent = ({
         hierarchyType: hierarchyType,
       },
     },
+    config: {
+      cacheTime: 1000000,
+      staleTime: 600000,
+    },
   };
 
   const { isLoading: hierarchyLoading, data: hierarchy } = Digit.Hooks.useCustomAPIHook(reqCriteria);
@@ -247,29 +251,32 @@ const SelectingBoundaryComponent = ({
       return;
     }
 
-    // Wrap ALL state updates in startTransition so React can show the loader
+    // Clear case: update state immediately (no startTransition) so child dropdowns
+    // reset their Select All / category checkboxes without delay.
+    if (!data || data.length === 0) {
+      const structure = createHierarchyStructure(hierarchy);
+      const check = structure?.[boundary.boundaryType];
+
+      if (check) {
+        const typesToRemoveSet = new Set([boundary?.boundaryType, ...check]);
+        const updatedSelectedData = selectedData?.filter((item) => !typesToRemoveSet.has(item?.type));
+        const updatedBoundaryData = { ...boundaryOptions };
+        typesToRemoveSet.forEach((type) => {
+          if (type !== boundary?.boundaryType && updatedBoundaryData?.hasOwnProperty(type)) {
+            updatedBoundaryData[type] = {};
+          }
+        });
+        if (!_.isEqual(selectedData, updatedSelectedData)) {
+          setSelectedData(updatedSelectedData);
+        }
+        setBoundaryOptions(updatedBoundaryData);
+      }
+      return;
+    }
+
+    // Wrap selection state updates in startTransition so React can show the loader
     // while the heavy re-render (memoized options, downstream effects) is processed.
     startTransition(() => {
-      if (!data || data.length === 0) {
-        const structure = createHierarchyStructure(hierarchy);
-        const check = structure?.[boundary.boundaryType];
-
-        if (check) {
-          const typesToRemoveSet = new Set([boundary?.boundaryType, ...check]);
-          const updatedSelectedData = selectedData?.filter((item) => !typesToRemoveSet.has(item?.type));
-          const updatedBoundaryData = { ...boundaryOptions };
-          typesToRemoveSet.forEach((type) => {
-            if (type !== boundary?.boundaryType && updatedBoundaryData?.hasOwnProperty(type)) {
-              updatedBoundaryData[type] = {};
-            }
-          });
-          if (!_.isEqual(selectedData, updatedSelectedData)) {
-            setSelectedData(updatedSelectedData);
-          }
-          setBoundaryOptions(updatedBoundaryData);
-        }
-        return;
-      }
 
       let res = isMultiSelect ? data?.map((ob) => ob?.[1]) || [] : [data];
       let transformedRes = [];

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -55,14 +55,36 @@ const SelectingBoundaryComponent = ({
   // Use restrictSelection from parent - no local state needed
   const restrictSelection = restrictSelectionPage;
   const [isPending, startTransition] = useTransition();
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [optionsPerType, setOptionsPerType] = useState({});
+  const [computingAll, setComputingAll] = useState(true);
+  const [boundaryData, setBoundaryData] = useState({});
+
+  // Refs for values the pipeline reads but should NOT restart when they change
+  // (the parent echoes our output back as props, which would cause an infinite loop).
+  const selectedData1Ref = useRef(selectedData1);
+  selectedData1Ref.current = selectedData1;
+  const boundaryOptionsPageRef = useRef(boundaryOptionsPage);
+  boundaryOptionsPageRef.current = boundaryOptionsPage;
+
+  // Track pipeline completion so post-pipeline user interactions can recompute optionsPerType
+  const pipelineDoneRef = useRef(false);
+  const pipelineBoundaryOptionsRef = useRef(null);
+
+  // Defer heavy computation until after the Loader has been painted.
+  useEffect(() => {
+    const rafId = requestAnimationFrame(() => {
+      setIsInitialized(true);
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, []);
 
   useEffect(() => {
+    // After the pipeline has set boundaryOptions, skip the parent echo
+    // (parent echoes our output back as props — don't let it override user-interaction changes).
+    if (pipelineDoneRef.current) return;
     setBoundaryOptions(boundaryOptionsPage);
   }, [boundaryOptionsPage]);
-
-  useEffect(() => {
-    setSelectedData(selectedData1);
-  }, [selectedData1]);
 
   const reqCriteria = {
     url: `/boundary-service/boundary-hierarchy-definition/_search`,
@@ -83,74 +105,6 @@ const SelectingBoundaryComponent = ({
 
   const { isLoading: hierarchyLoading, data: hierarchy } = Digit.Hooks.useCustomAPIHook(reqCriteria);
 
-  function processData(rootNode, parentPath = "", lowestBoundaryType) {
-    // Iterative tree walk with explicit stack — avoids deep recursion overhead
-    // and uses direct property assignment instead of object spread for O(n) instead of O(n²)
-    const result = {};
-    const stack = [{ node: rootNode, parentPath }];
-
-    while (stack.length > 0) {
-      const { node, parentPath: pPath } = stack.pop();
-      if (!node) continue;
-
-      const bType = node.boundaryType;
-      const code = node.code;
-      const currentPath = pPath ? `${code}.${pPath}` : code;
-
-      if (!result[bType]) result[bType] = {};
-      result[bType][code] = pPath || "mz";
-
-      if (bType === lowestBoundaryType) continue;
-
-      const children = node.children;
-      if (children && children.length > 0) {
-        for (let i = children.length - 1; i >= 0; i--) {
-          stack.push({ node: children[i], parentPath: currentPath });
-        }
-      }
-    }
-    return result;
-  }
-
-  const boundaryData = useMemo(() => processData(data?.[0], "", lowest), [data, lowest]);
-
-  const updateBoundaryOptions = (selectedData1, boundaryData, hierarchy) => {
-    // Pre-build a lookup from parentBoundaryType → childBoundaryType
-    const parentToChild = {};
-    hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.forEach((boundary) => {
-      if (boundary.parentBoundaryType) {
-        parentToChild[boundary.parentBoundaryType] = boundary.boundaryType;
-      }
-    });
-
-    // Collect all updates, then apply as a single setBoundaryOptions call
-    const updates = {};
-    selectedData1?.forEach((item) => {
-      const { type, code } = item;
-      const childBoundaryType = parentToChild[type];
-      if (childBoundaryType && boundaryData[childBoundaryType]) {
-        if (!updates[childBoundaryType]) updates[childBoundaryType] = {};
-        const childEntries = boundaryData[childBoundaryType];
-        for (const key in childEntries) {
-          if (childEntries[key].split(".").includes(code)) {
-            updates[childBoundaryType][key] = childEntries[key];
-          }
-        }
-      }
-    });
-
-    // Single state update instead of N updates
-    if (Object.keys(updates).length > 0) {
-      setBoundaryOptions((prevOptions) => {
-        const newOptions = { ...prevOptions };
-        for (const childType in updates) {
-          newOptions[childType] = { ...newOptions[childType], ...updates[childType] };
-        }
-        return newOptions;
-      });
-    }
-  };
-
   useEffect(() => {
     setSelectedData(selectedData1);
     const rootItem = selectedData1?.find((item) => item?.isRoot === true);
@@ -158,18 +112,6 @@ const SelectingBoundaryComponent = ({
       setParentRoot(rootItem.type);
     }
   }, [selectedData1]);
-
-  const isBoundaryDataValid = useMemo(() => {
-    return boundaryData && Object.keys(boundaryData).every((key) => key !== "undefined");
-  }, [boundaryData]);
-
-  useEffect(() => {
-    if (isBoundaryDataValid && hierarchy && selectedData1?.length > 0 && boundaryOptions?.[parentRoot]) {
-      startTransition(() => {
-        updateBoundaryOptions(selectedData1, boundaryData, hierarchy);
-      });
-    }
-  }, [hierarchy, isBoundaryDataValid, boundaryOptions?.[parentRoot]]);
 
   function createHierarchyStructure(hierarchy) {
     const hierarchyStructure = {};
@@ -208,27 +150,23 @@ const SelectingBoundaryComponent = ({
     return hierarchyStructure;
   }
 
-  useEffect(() => {
-    if (boundaryData[parentRoot]) {
-      if (!boundaryOptions?.[parentRoot]) {
-        setBoundaryOptions((prevOptions) => ({
-          ...prevOptions,
-          [parentRoot]: boundaryData[parentRoot],
-        }));
-      }
-    }
-  }, [boundaryData, boundaryOptions, parentRoot]);
-
   // Pre-build a reverse index: for each child boundary type, map parent code → { childKey: path }
   // This turns the O(selectedItems * childKeys) hot loop into O(selectedItems) lookups.
-  const childIndexCache = useRef({ key: null, dataRef: null, index: null });
+  // Multi-entry cache: stores indexes for ALL boundary types to avoid thrashing when
+  // updateBoundaryOptions iterates across multiple hierarchy levels.
+  const childIndexCache = useRef({ dataRef: null, indexes: new Map() });
 
   const getChildIndex = useCallback((childBoundaryType) => {
     if (!childBoundaryType || !boundaryData[childBoundaryType]) return null;
     const cache = childIndexCache.current;
-    // Cache hit — same boundary type AND same boundaryData reference
-    if (cache.key === childBoundaryType && cache.dataRef === boundaryData) {
-      return cache.index;
+    // Invalidate entire cache when boundaryData reference changes
+    if (cache.dataRef !== boundaryData) {
+      cache.dataRef = boundaryData;
+      cache.indexes = new Map();
+    }
+    // Cache hit
+    if (cache.indexes.has(childBoundaryType)) {
+      return cache.indexes.get(childBoundaryType);
     }
     // Build: parentCode → { childKey: path, ... }
     const index = {};
@@ -241,7 +179,7 @@ const SelectingBoundaryComponent = ({
         index[part][key] = path;
       }
     }
-    childIndexCache.current = { key: childBoundaryType, dataRef: boundaryData, index };
+    cache.indexes.set(childBoundaryType, index);
     return index;
   }, [boundaryData]);
 
@@ -412,16 +350,231 @@ const SelectingBoundaryComponent = ({
     return levels.filter((_, index) => index <= lowestIndex);
   }, [hierarchy, lowest]);
 
-  // Pre-compute options per boundary type once (avoids re-building 50k-item arrays in JSX)
-  const optionsPerType = useMemo(() => {
-    const result = {};
+  // ── Unified async pipeline ──
+  // Merges tree walk (processData), boundary options update, and optionsPerType into ONE
+  // async flow with time-based yielding (~4ms per chunk). This avoids cascading effects
+  // where each state change triggers re-renders and restarts, causing cumulative main-thread blocking.
+  useEffect(() => {
+    if (!isInitialized || !data?.[0] || !hierarchy) return;
+
+    pipelineDoneRef.current = false;
+    pipelineBoundaryOptionsRef.current = null;
+    setComputingAll(true);
+    let cancelled = false;
+
+    // Yield to browser every ~4ms to keep loader animation at 60fps
+    const YIELD_MS = 4;
+    const yieldControl = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runPipeline = async () => {
+      let lastYield = performance.now();
+      const maybeYield = async () => {
+        if (performance.now() - lastYield >= YIELD_MS) {
+          await yieldControl();
+          if (cancelled) return false;
+          lastYield = performance.now();
+        }
+        return true;
+      };
+
+      // ── Step 1: Tree walk → boundaryData ──
+      const bData = {};
+      const stack = [{ node: data[0], parentPath: "" }];
+
+      while (stack.length > 0) {
+        if (cancelled) return;
+        const { node, parentPath: pPath } = stack.pop();
+        if (!node) continue;
+
+        const bType = node.boundaryType;
+        const code = node.code;
+        const currentPath = pPath ? `${code}.${pPath}` : code;
+
+        if (!bData[bType]) bData[bType] = {};
+        bData[bType][code] = pPath || "mz";
+
+        if (bType !== lowest) {
+          const children = node.children;
+          if (children && children.length > 0) {
+            for (let i = children.length - 1; i >= 0; i--) {
+              stack.push({ node: children[i], parentPath: currentPath });
+            }
+          }
+        }
+
+        if (!(await maybeYield())) return;
+      }
+
+      if (cancelled) return;
+
+      // Validate boundaryData
+      const bdKeys = Object.keys(bData);
+      if (bdKeys.length === 0 || bdKeys.some((k) => k === "undefined")) {
+        setBoundaryData(bData);
+        setComputingAll(false);
+        return;
+      }
+
+      // ── Step 2: Merge boundary options (root + child updates) ──
+      const rootType = hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.find(
+        (b) => !b.parentBoundaryType
+      )?.boundaryType;
+
+      // Read latest values from refs (not deps) to avoid infinite loop
+      // when parent echoes our output back as props.
+      const currentBoundaryOptionsPage = boundaryOptionsPageRef.current;
+      const currentSelectedData = selectedData1Ref.current;
+
+      let mergedOptions = { ...currentBoundaryOptionsPage };
+
+      // Set root options if missing
+      if (rootType && bData[rootType] && !mergedOptions[rootType]) {
+        mergedOptions = { ...mergedOptions, [rootType]: bData[rootType] };
+      }
+
+      // Build child indexes and update boundary options (like updateBoundaryOptions)
+      if (currentSelectedData?.length > 0 && mergedOptions[rootType]) {
+        const parentToChild = {};
+        hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.forEach((b) => {
+          if (b.parentBoundaryType) parentToChild[b.parentBoundaryType] = b.boundaryType;
+        });
+
+        // Build all needed child indexes with yielding
+        const childIndexes = {};
+        for (const childType of Object.values(parentToChild)) {
+          if (cancelled) return;
+          if (!bData[childType]) continue;
+
+          const index = {};
+          const childEntries = bData[childType];
+          for (const key in childEntries) {
+            const path = childEntries[key];
+            const parts = path.split(".");
+            for (const part of parts) {
+              if (!index[part]) index[part] = {};
+              index[part][key] = path;
+            }
+            if (!(await maybeYield())) return;
+          }
+          childIndexes[childType] = index;
+        }
+
+        // Collect updates using indexes
+        const updates = {};
+        currentSelectedData.forEach((item) => {
+          const childType = parentToChild[item.type];
+          if (childType && childIndexes[childType]) {
+            if (!updates[childType]) updates[childType] = {};
+            const matches = childIndexes[childType][item.code];
+            if (matches) Object.assign(updates[childType], matches);
+          }
+        });
+
+        if (Object.keys(updates).length > 0) {
+          for (const childType in updates) {
+            mergedOptions[childType] = { ...mergedOptions[childType], ...updates[childType] };
+          }
+        }
+      }
+
+      if (cancelled) return;
+      await yieldControl();
+      if (cancelled) return;
+      lastYield = performance.now();
+
+      // ── Step 3: Compute optionsPerType from mergedOptions ──
+      const levels = hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy || [];
+      const lowestIndex = levels.findIndex((b) => b.boundaryType === lowest);
+      const visLevels = levels.filter((_, index) => index <= lowestIndex);
+
+      const frozenSet = frozenData?.length > 0
+        ? new Set(frozenData.map((f) => `${f.code}::${f.type}`))
+        : null;
+
+      const optResult = {};
+
+      for (let levelIdx = 0; levelIdx < visLevels.length; levelIdx++) {
+        if (cancelled) return;
+
+        const boundary = visLevels[levelIdx];
+        const bType = boundary.boundaryType;
+        const value = mergedOptions[bType];
+
+        if (boundary.parentBoundaryType == null) {
+          if (value) {
+            const keys = Object.keys(value);
+            const arr = new Array(keys.length);
+            for (let i = 0; i < keys.length; i++) {
+              arr[i] = { code: keys[i], name: keys[i], type: bType };
+            }
+            optResult[bType] = arr;
+          } else {
+            optResult[bType] = [];
+          }
+        } else {
+          if (value) {
+            const entries = Object.entries(value);
+            const skipFilter = restrictSelection === false;
+            const grouped = new Map();
+
+            for (let i = 0; i < entries.length; i++) {
+              const subkey = entries[i][0];
+              const item = entries[i][1];
+              if (!skipFilter && frozenSet) {
+                if (frozenType === "filter" && frozenSet.has(`${subkey}::${bType}`)) continue;
+              }
+              const parentCode = item ? item.split(".")[0] : "";
+              let group = grouped.get(parentCode);
+              if (!group) {
+                group = { code: parentCode, name: parentCode, options: [] };
+                grouped.set(parentCode, group);
+              }
+              group.options.push({ code: subkey, name: subkey, type: bType, parent: parentCode });
+
+              if (!(await maybeYield())) return;
+            }
+
+            optResult[bType] = Array.from(grouped.values());
+          } else {
+            optResult[bType] = [];
+          }
+        }
+
+        await yieldControl();
+        if (cancelled) return;
+        lastYield = performance.now();
+      }
+
+      if (cancelled) return;
+
+      // ── Step 4: Set all state at once — no cascading re-renders ──
+      pipelineDoneRef.current = true;
+      pipelineBoundaryOptionsRef.current = mergedOptions;
+      setBoundaryData(bData);
+      setBoundaryOptions(mergedOptions);
+      setOptionsPerType(optResult);
+      setComputingAll(false);
+    };
+
+    runPipeline();
+    return () => { cancelled = true; };
+  }, [isInitialized, data, lowest, hierarchy, restrictSelection, frozenData, frozenType]);
+
+  // Post-pipeline sync: recompute optionsPerType when boundaryOptions changes from user interaction
+  // (e.g., user selects a root boundary → handleBoundaryChange sets child options).
+  // Skips the pipeline's own setBoundaryOptions output via reference comparison.
+  useEffect(() => {
+    if (computingAll) return;
+    // Skip if this is the pipeline's own output
+    if (boundaryOptions === pipelineBoundaryOptionsRef.current) return;
+
     const frozenSet = frozenData?.length > 0
       ? new Set(frozenData.map((f) => `${f.code}::${f.type}`))
       : null;
 
+    const result = {};
     visibleBoundaryLevels.forEach((boundary) => {
       const bType = boundary.boundaryType;
-      // Direct lookup by boundary type instead of iterating all entries with startsWith
       const value = boundaryOptions?.[bType];
 
       if (boundary.parentBoundaryType == null) {
@@ -437,45 +590,49 @@ const SelectingBoundaryComponent = ({
           result[bType] = [];
         }
       } else {
-        // Nested level — grouped options with frozen filtering
+        // Nested level — group by parent code
         if (value) {
           const entries = Object.entries(value);
-          const arr = [];
           const skipFilter = restrictSelection === false;
+          const grouped = new Map();
+
           for (let i = 0; i < entries.length; i++) {
             const subkey = entries[i][0];
             const item = entries[i][1];
             if (!skipFilter && frozenSet) {
-              const isFrozen = frozenSet.has(`${subkey}::${bType}`);
-              if (frozenType === "filter" && isFrozen) continue;
+              if (frozenType === "filter" && frozenSet.has(`${subkey}::${bType}`)) continue;
             }
             const parentCode = item ? item.split(".")[0] : "";
-            arr.push({
-              code: parentCode,
-              name: parentCode,
-              options: [{ code: subkey, name: subkey, type: bType, parent: parentCode }],
-            });
+            let group = grouped.get(parentCode);
+            if (!group) {
+              group = { code: parentCode, name: parentCode, options: [] };
+              grouped.set(parentCode, group);
+            }
+            group.options.push({ code: subkey, name: subkey, type: bType, parent: parentCode });
           }
-          result[bType] = arr;
+
+          result[bType] = Array.from(grouped.values());
         } else {
           result[bType] = [];
         }
       }
     });
-    return result;
-  }, [boundaryOptions, visibleBoundaryLevels, restrictSelection, frozenData, frozenType]);
+
+    setOptionsPerType(result);
+  }, [boundaryOptions, computingAll, visibleBoundaryLevels, restrictSelection, frozenData, frozenType]);
 
   // Pre-compute selected items grouped by type
   const selectedPerType = useMemo(() => {
+    if (computingAll) return {};
     const result = {};
     selectedData?.forEach((item) => {
       if (!result[item?.type]) result[item.type] = [];
       result[item.type].push(item);
     });
     return result;
-  }, [selectedData]);
+  }, [selectedData, computingAll]);
 
-  if (hierarchyLoading) return <Loader page={true} variant={"PageLoader"} />;
+  if (hierarchyLoading || !isInitialized || computingAll) return <Loader page={true} variant={"PageLoader"} />;
 
   return (
     <>

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -70,6 +70,18 @@ const SelectingBoundaryComponent = ({
   // Track pipeline completion so post-pipeline user interactions can recompute optionsPerType
   const pipelineDoneRef = useRef(false);
   const pipelineBoundaryOptionsRef = useRef(null);
+  // Flag to skip the first post-pipeline sync (pipeline already set optionsPerType directly)
+  const pipelineJustCompletedRef = useRef(false);
+
+  // Refs for parent props that should NOT restart the pipeline when their identity changes.
+  // hierarchy and data are stable via react-query caching, but frozenData/frozenType/restrictSelection
+  // come from parent props and can be recreated on every render.
+  const frozenDataRef = useRef(frozenData);
+  frozenDataRef.current = frozenData;
+  const frozenTypeRef = useRef(frozenType);
+  frozenTypeRef.current = frozenType;
+  const restrictSelectionRef = useRef(restrictSelection);
+  restrictSelectionRef.current = restrictSelection;
 
   // Defer heavy computation until after the Loader has been painted.
   useEffect(() => {
@@ -80,9 +92,9 @@ const SelectingBoundaryComponent = ({
   }, []);
 
   useEffect(() => {
-    // After the pipeline has set boundaryOptions, skip the parent echo
-    // (parent echoes our output back as props — don't let it override user-interaction changes).
-    if (pipelineDoneRef.current) return;
+    // Skip only the parent's echo of our own pipeline output; still accept genuine
+    // parent-driven updates (e.g. external resets) so they are not dropped.
+    if (pipelineDoneRef.current && boundaryOptionsPage === pipelineBoundaryOptionsRef.current) return;
     setBoundaryOptions(boundaryOptionsPage);
   }, [boundaryOptionsPage]);
 
@@ -98,7 +110,7 @@ const SelectingBoundaryComponent = ({
       },
     },
     config: {
-      cacheTime: 1000000,
+      gcTime: 1000000,
       staleTime: 600000,
     },
   };
@@ -354,13 +366,26 @@ const SelectingBoundaryComponent = ({
   // Merges tree walk (processData), boundary options update, and optionsPerType into ONE
   // async flow with time-based yielding (~4ms per chunk). This avoids cascading effects
   // where each state change triggers re-renders and restarts, causing cumulative main-thread blocking.
+  //
+  // frozenData/frozenType/restrictSelection are read from refs to avoid restarting
+  // the expensive tree walk when only their identity changes on parent re-render.
+  // Changes to those props are handled by the post-pipeline sync effect which
+  // recomputes only optionsPerType (Step 3) without redoing Steps 1-2.
   useEffect(() => {
     if (!isInitialized || !data?.[0] || !hierarchy) return;
 
     pipelineDoneRef.current = false;
     pipelineBoundaryOptionsRef.current = null;
+    pipelineJustCompletedRef.current = false;
     setComputingAll(true);
     let cancelled = false;
+
+    // Snapshot current values — hierarchy/data are stable react-query refs,
+    // frozenData/frozenType/restrictSelection use refs to avoid dep-array churn.
+    const pipelineHierarchy = hierarchy;
+    const pipelineFrozenData = frozenDataRef.current;
+    const pipelineFrozenType = frozenTypeRef.current;
+    const pipelineRestriction = restrictSelectionRef.current;
 
     // Yield to browser every ~4ms to keep loader animation at 60fps
     const YIELD_MS = 4;
@@ -410,13 +435,15 @@ const SelectingBoundaryComponent = ({
       // Validate boundaryData
       const bdKeys = Object.keys(bData);
       if (bdKeys.length === 0 || bdKeys.some((k) => k === "undefined")) {
+        console.warn("[SelectingBoundaryComponent] Invalid boundary data keys:", bdKeys);
+        pipelineDoneRef.current = true;
         setBoundaryData(bData);
         setComputingAll(false);
         return;
       }
 
       // ── Step 2: Merge boundary options (root + child updates) ──
-      const rootType = hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.find(
+      const rootType = pipelineHierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.find(
         (b) => !b.parentBoundaryType
       )?.boundaryType;
 
@@ -435,7 +462,7 @@ const SelectingBoundaryComponent = ({
       // Build child indexes and update boundary options (like updateBoundaryOptions)
       if (currentSelectedData?.length > 0 && mergedOptions[rootType]) {
         const parentToChild = {};
-        hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.forEach((b) => {
+        pipelineHierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy?.forEach((b) => {
           if (b.parentBoundaryType) parentToChild[b.parentBoundaryType] = b.boundaryType;
         });
 
@@ -483,12 +510,12 @@ const SelectingBoundaryComponent = ({
       lastYield = performance.now();
 
       // ── Step 3: Compute optionsPerType from mergedOptions ──
-      const levels = hierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy || [];
+      const levels = pipelineHierarchy?.BoundaryHierarchy?.[0]?.boundaryHierarchy || [];
       const lowestIndex = levels.findIndex((b) => b.boundaryType === lowest);
       const visLevels = levels.filter((_, index) => index <= lowestIndex);
 
-      const frozenSet = frozenData?.length > 0
-        ? new Set(frozenData.map((f) => `${f.code}::${f.type}`))
+      const frozenSet = pipelineFrozenData?.length > 0
+        ? new Set(pipelineFrozenData.map((f) => `${f.code}::${f.type}`))
         : null;
 
       const optResult = {};
@@ -514,14 +541,14 @@ const SelectingBoundaryComponent = ({
         } else {
           if (value) {
             const entries = Object.entries(value);
-            const skipFilter = restrictSelection === false;
+            const skipFilter = pipelineRestriction === false;
             const grouped = new Map();
 
             for (let i = 0; i < entries.length; i++) {
               const subkey = entries[i][0];
               const item = entries[i][1];
               if (!skipFilter && frozenSet) {
-                if (frozenType === "filter" && frozenSet.has(`${subkey}::${bType}`)) continue;
+                if (pipelineFrozenType === "filter" && frozenSet.has(`${subkey}::${bType}`)) continue;
               }
               const parentCode = item ? item.split(".")[0] : "";
               let group = grouped.get(parentCode);
@@ -549,6 +576,7 @@ const SelectingBoundaryComponent = ({
 
       // ── Step 4: Set all state at once — no cascading re-renders ──
       pipelineDoneRef.current = true;
+      pipelineJustCompletedRef.current = true;
       pipelineBoundaryOptionsRef.current = mergedOptions;
       setBoundaryData(bData);
       setBoundaryOptions(mergedOptions);
@@ -558,15 +586,21 @@ const SelectingBoundaryComponent = ({
 
     runPipeline();
     return () => { cancelled = true; };
-  }, [isInitialized, data, lowest, hierarchy, restrictSelection, frozenData, frozenType]);
+  }, [isInitialized, data, lowest, hierarchy]);
 
-  // Post-pipeline sync: recompute optionsPerType when boundaryOptions changes from user interaction
-  // (e.g., user selects a root boundary → handleBoundaryChange sets child options).
-  // Skips the pipeline's own setBoundaryOptions output via reference comparison.
+  // Post-pipeline sync: recompute optionsPerType when boundaryOptions, frozenData,
+  // frozenType, or restrictSelection change after the pipeline has completed.
+  // This covers: (a) user interaction via handleBoundaryChange updating child options,
+  // (b) frozenData/frozenType/restrictSelection prop changes that only need Step 3 recomputation
+  //     without redoing the expensive tree walk (Steps 1-2).
+  // Skips the first run after pipeline completion (pipeline already set optionsPerType directly).
   useEffect(() => {
     if (computingAll) return;
-    // Skip if this is the pipeline's own output
-    if (boundaryOptions === pipelineBoundaryOptionsRef.current) return;
+    // Skip the pipeline's own state update — it already set optionsPerType directly.
+    if (pipelineJustCompletedRef.current) {
+      pipelineJustCompletedRef.current = false;
+      return;
+    }
 
     const frozenSet = frozenData?.length > 0
       ? new Set(frozenData.map((f) => `${f.code}::${f.type}`))

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -70,8 +70,11 @@ const SelectingBoundaryComponent = ({
   // Track pipeline completion so post-pipeline user interactions can recompute optionsPerType
   const pipelineDoneRef = useRef(false);
   const pipelineBoundaryOptionsRef = useRef(null);
-  // Flag to skip the first post-pipeline sync (pipeline already set optionsPerType directly)
-  const pipelineJustCompletedRef = useRef(false);
+  // Snapshot of frozenData/frozenType/restrictSelection used by the pipeline's Step 3.
+  // After pipeline completion, the post-pipeline effect compares current props against
+  // this snapshot — if they match, it skips (pipeline already computed correctly).
+  // If they differ (props changed during pipeline run), it falls through and recomputes.
+  const pipelineSnapshotRef = useRef(null);
 
   // Refs for parent props that should NOT restart the pipeline when their identity changes.
   // hierarchy and data are stable via react-query caching, but frozenData/frozenType/restrictSelection
@@ -376,7 +379,7 @@ const SelectingBoundaryComponent = ({
 
     pipelineDoneRef.current = false;
     pipelineBoundaryOptionsRef.current = null;
-    pipelineJustCompletedRef.current = false;
+    pipelineSnapshotRef.current = null;
     setComputingAll(true);
     let cancelled = false;
 
@@ -576,7 +579,11 @@ const SelectingBoundaryComponent = ({
 
       // ── Step 4: Set all state at once — no cascading re-renders ──
       pipelineDoneRef.current = true;
-      pipelineJustCompletedRef.current = true;
+      pipelineSnapshotRef.current = {
+        frozenData: pipelineFrozenData,
+        frozenType: pipelineFrozenType,
+        restrictSelection: pipelineRestriction,
+      };
       pipelineBoundaryOptionsRef.current = mergedOptions;
       setBoundaryData(bData);
       setBoundaryOptions(mergedOptions);
@@ -593,13 +600,22 @@ const SelectingBoundaryComponent = ({
   // This covers: (a) user interaction via handleBoundaryChange updating child options,
   // (b) frozenData/frozenType/restrictSelection prop changes that only need Step 3 recomputation
   //     without redoing the expensive tree walk (Steps 1-2).
-  // Skips the first run after pipeline completion (pipeline already set optionsPerType directly).
+  // Skips the first run after pipeline completion only if props haven't changed during pipeline.
   useEffect(() => {
     if (computingAll) return;
-    // Skip the pipeline's own state update — it already set optionsPerType directly.
-    if (pipelineJustCompletedRef.current) {
-      pipelineJustCompletedRef.current = false;
-      return;
+    // After pipeline completion, check if the props it used still match current values.
+    // If they do, skip — pipeline already computed optionsPerType with these values.
+    // If they differ (props changed during pipeline execution), fall through to recompute.
+    if (pipelineSnapshotRef.current) {
+      const snap = pipelineSnapshotRef.current;
+      pipelineSnapshotRef.current = null;
+      if (
+        frozenData === snap.frozenData &&
+        frozenType === snap.frozenType &&
+        restrictSelection === snap.restrictSelection
+      ) {
+        return;
+      }
     }
 
     const frozenSet = frozenData?.length > 0

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -167,12 +167,12 @@ const SetupCampaign = () => {
       select: (data) => {
         return data?.[0];
       },
-      // Override hook defaults (cacheTime: 0, staleTime: 0) to prevent background refetches.
+      // Override hook defaults (gcTime: 0, staleTime: 0) to prevent background refetches.
       // Without this, every SetupCampaign re-render finds data stale and triggers a refetch,
       // causing cascading re-renders and unresponsive dropdowns on the boundary step.
       // Explicit draftRefetch() calls (after update operations) still bypass staleTime.
       staleTime: 600000,
-      cacheTime: 1000000,
+      gcTime: 1000000,
     },
   });
 

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/SetupCampaign.js
@@ -167,6 +167,12 @@ const SetupCampaign = () => {
       select: (data) => {
         return data?.[0];
       },
+      // Override hook defaults (cacheTime: 0, staleTime: 0) to prevent background refetches.
+      // Without this, every SetupCampaign re-render finds data stale and triggers a refetch,
+      // causing cascading re-renders and unresponsive dropdowns on the boundary step.
+      // Explicit draftRefetch() calls (after update operations) still bypass staleTime.
+      staleTime: 600000,
+      cacheTime: 1000000,
     },
   });
 
@@ -1154,6 +1160,13 @@ const SetupCampaign = () => {
   const closeToast = () => {
     setShowToast(null);
   };
+
+  // Show loader while campaign data is being fetched for any editing flow.
+  // The existing isDraft/isPreview checks below miss cases like draft=null&isDraft=true
+  // where draftLoading is true but neither condition matches.
+  if (id && draftLoading) {
+    return <Loader page={true} variant={"PageLoader"} />;
+  }
 
   if (isPreview === "true" && !draftData) {
     return <Loader page={true} variant={"PageLoader"} />;


### PR DESCRIPTION
## Summary
- **Fix boundary selection page performance**: Added unified async pipeline with time-based yielding (~4ms) for processing 20k+ boundary items, keeping the loader animation smooth at 60fps instead of freezing the UI
- **Fix child dropdowns not populating in new campaigns**: After the pipeline completes, user interactions (selecting root boundaries) now trigger a post-pipeline recomputation of dropdown options so child dropdowns render correctly
- **Fix double scrollbar in dropdowns**: Overrode outer container `overflow-y: auto` / `max-height` that conflicted with react-window's internal virtualized scroll
- **Optimize dropdown rendering**: Converted O(n²) `flattenOptions` concat to O(n) push, added pre-built child index cache for O(n) boundary option updates instead of O(n*m)
- **Add API caching**: Added `staleTime`/`cacheTime` to project-type search and hierarchy API calls to prevent redundant background refetches
- **Fix Select All not resetting on parent dropdown clear**: When a parent boundary dropdown is cleared, child dropdowns now immediately reset their Select All and per-category checkboxes
- **Fix single-option dropdown CSS**: Added `+2` height buffer and `overflowX: hidden` only when there is one dropdown option

## Test plan
- [ ] Navigate to boundary selection page with 20k+ boundaries — confirm loader shows and animates smoothly
- [ ] After loading, confirm all boundary level dropdowns render with correct options
- [ ] Create a new campaign and select root boundaries — confirm child dropdowns populate correctly
- [ ] Update an existing campaign — confirm all pre-selected boundaries load and display correctly
- [ ] Select boundaries at all levels, then Clear All on the root dropdown — confirm all child Select All checkboxes reset
- [ ] Open dropdowns with many options — confirm no double scrollbar appears
- [ ] Open a dropdown with a single option — confirm no horizontal scroll or height glitch
- [ ] Confirm no redundant API calls in the Network tab when navigating between steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness for campaign boundary selection by deferring heavy computation and using smoother transition-based updates.
  * Optimized dropdown state updates to reduce unnecessary recalculation.
  * Reduced background refetching during campaign setup to prevent cascading rerenders.

* **Bug Fixes**
  * Improved synchronization when selections are cleared or updated externally (including select-all/category behavior).
  * Corrected virtualized dropdown sizing/scrolling and ensured consistent overflow behavior for server-style menus.

* **UX / Loading**
  * Enhanced loading feedback during boundary/localization preparation and editing flows, including early full-page loading when a draft is still loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->