### PR TITLE
BUGFIX/HCMPRE-3662: Campaign creation fixes - hierarchy popup, delivery rules, UI improvements

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CampaignName.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CampaignName.js
@@ -126,6 +126,7 @@ const CampaignName = ({ onSelect, formData, control, formState, ...props }) => {
           placeholder={t(I18N_KEYS.COMPONENTS.HCM_CAMPAIGN_NAME_EXAMPLE)}
           value={name}
           onChange={(event) => {
+            if (event.target.value.length > 30) return;
             setStartValidation(true);
             setName(event.target.value);
           }}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CampaignNameInput.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CampaignNameInput.js
@@ -70,6 +70,7 @@ const CampaignNameInput = ({ onSelect, formData, customProps, ...props }) => {
 
   const handleChange = (event) => {
     const newValue = event.target.value;
+    if (newValue.length > 30) return;
     setName(newValue);
     setHasInteracted(true);
   };

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/ComponentToRender.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/ComponentToRender.js
@@ -102,8 +102,9 @@ const ComponentToRender = ({ field, t: customT, selectedField, isSelected }) => 
     const panelContent = fieldPanelConfig?.drawerPanelConfig?.content || [];
     const defaultValueConfig = panelContent.find((item) => item.id === "defaultValue");
     const enabledTypes = defaultValueConfig?.visibilityEnabledFor || [];
-    if (enabledTypes.includes(field?.type) && typeof field?.value === "number") {
-      return field.value;
+    if (enabledTypes.includes(field?.type) && field?.value != null && field?.value !== "" && field?.value !== true) {
+      const num = Number(field.value);
+      if (!isNaN(num)) return num;
     }
     return "";
   }, [fieldPanelConfig, field?.type, field?.value]);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/ComponentToRender.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/ComponentToRender.js
@@ -11,6 +11,7 @@ import { getComponentFromMasterData } from "../pages/employee/NewAppConfiguratio
 
 const ComponentToRender = ({ field, t: customT, selectedField, isSelected }) => {
   const { byName } = useSelector((state) => state.fieldTypeMaster);
+  const { byName: fieldPanelConfig } = useSelector((state) => state.fieldPanelMaster);
   const { t } = useTranslation();
   const fieldRef = useRef(null);
   const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -96,6 +97,17 @@ const ComponentToRender = ({ field, t: customT, selectedField, isSelected }) => 
     return field?.isMdms && isValidSchema ? "code" : "name";
   }, [field?.isMdms, isValidSchema]);
 
+  // Show defaultValue in preview for field types where it's enabled in MDMS panel config
+  const previewValue = useMemo(() => {
+    const panelContent = fieldPanelConfig?.drawerPanelConfig?.content || [];
+    const defaultValueConfig = panelContent.find((item) => item.id === "defaultValue");
+    const enabledTypes = defaultValueConfig?.visibilityEnabledFor || [];
+    if (enabledTypes.includes(field?.type) && typeof field?.value === "number") {
+      return field.value;
+    }
+    return "";
+  }, [fieldPanelConfig, field?.type, field?.value]);
+
   return (
     <div ref={fieldRef}>
       <FieldV1
@@ -141,7 +153,7 @@ const ComponentToRender = ({ field, t: customT, selectedField, isSelected }) => 
         withoutLabel={field?.format === "checkbox" ? true : false}
         required={getFieldTypeFromMasterData2(field) === "custom" ? null : field?.required}
         type={fieldType}
-        value={""}
+        value={previewValue}
         disabled={field?.readOnly || false}
         showToolTip={true}
       />

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/CycleSelection.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/CycleSelection.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Fragment } from "react";
+import React, { useState, useEffect, useMemo, Fragment } from "react";
 import { useTranslation } from "react-i18next";
 import { FieldV1, Card, LabelFieldPair, RadioButtons } from "@egovernments/digit-ui-components";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
@@ -7,42 +7,63 @@ const CycleSelection = ({ onSelect, formData, ...props }) => {
   const { t } = useTranslation();
   const [selectedOption, setSelectedOption] = useState(formData?.CycleSelection);
 
-  const options = [
+  // Read roundTypes from project type MDMS config.
+  // Possible values: ["SINGLE_ROUND"], ["MULTI_ROUND"], ["SINGLE_ROUND", "MULTI_ROUND"]
+  const roundTypes = formData?.CampaignType?.roundTypes;
+
+  const allOptions = useMemo(() => [
     { code: "HCM_SINGLE_ROUND", name: t(I18N_KEYS.COMMON.HCM_SINGLE_ROUND) },
     { code: "HCM_MULTI_ROUND", name: t(I18N_KEYS.COMPONENTS.HCM_MULTI_ROUND) },
-  ];
+  ], [t]);
 
-useEffect(()=>{
-  if(formData?.CampaignType?.cycles?.length > 1){
-    setSelectedOption("HCM_MULTI_ROUND");
-  }
-  else{
-     setSelectedOption("HCM_SINGLE_ROUND");
-  }
+  // Filter options based on roundTypes config; show all if not configured
+  const options = useMemo(() => {
+    if (!roundTypes || !Array.isArray(roundTypes) || roundTypes.length === 0) {
+      return allOptions;
+    }
+    return allOptions.filter((opt) => {
+      if (opt.code === "HCM_SINGLE_ROUND") return roundTypes.includes("SINGLE_ROUND");
+      if (opt.code === "HCM_MULTI_ROUND") return roundTypes.includes("MULTI_ROUND");
+      return false;
+    });
+  }, [allOptions, roundTypes]);
 
-},[formData?.CampaignType?.code])
+  // Disabled when only one round type is allowed
+  const isDisabled = !roundTypes || !Array.isArray(roundTypes) || roundTypes.length < 2;
 
-  useEffect(() =>{
+  useEffect(() => {
+    if (!roundTypes || !Array.isArray(roundTypes) || roundTypes.length === 0) {
+      // No roundTypes configured — default to single round, disabled
+      setSelectedOption("HCM_SINGLE_ROUND");
+    } else if (roundTypes.length === 1) {
+      // Only one option — auto-select it
+      setSelectedOption(roundTypes[0] === "MULTI_ROUND" ? "HCM_MULTI_ROUND" : "HCM_SINGLE_ROUND");
+    } else if (!selectedOption) {
+      // Both options available and no prior selection — default to single round
+      setSelectedOption("HCM_SINGLE_ROUND");
+    }
+  }, [formData?.CampaignType?.code]);
+
+  useEffect(() => {
     onSelect("CycleSelection", selectedOption);
-
-  },[selectedOption])
+  }, [selectedOption]);
 
   return (
     <>
-    {formData?.CampaignType && (
-      <LabelFieldPair className="beneficiary-selection-label">
-        <RadioButtons
-          onSelect={(selected) => {
-            setSelectedOption(selected.code);
-          }}
-          disabled = {true}
-          options={options}
-          optionsKey="name"
-          selectedOption={options.find((opt) => opt.code === selectedOption)}
-          value={selectedOption}
-        />
-      </LabelFieldPair>
-    )}
+      {formData?.CampaignType && (
+        <LabelFieldPair className="beneficiary-selection-label">
+          <RadioButtons
+            onSelect={(selected) => {
+              setSelectedOption(selected.code);
+            }}
+            disabled={isDisabled}
+            options={options}
+            optionsKey="name"
+            selectedOption={options.find((opt) => opt.code === selectedOption)}
+            value={selectedOption}
+          />
+        </LabelFieldPair>
+      )}
     </>
   );
 };

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CreateCampaignComponents/SelectHierarchy.js
@@ -17,12 +17,24 @@ import {
 const MAX_VISIBLE_LEVELS = 5;
 
 const hasDependentData = (formData) => {
+  // Check for actual data content, not just key existence — IndexedDB keys
+  // can persist across sessions/campaigns and produce false positives.
+  const hasBoundarySelections =
+    formData?.HCM_CAMPAIGN_SELECTING_BOUNDARY_DATA?.boundaryType?.selectedData?.length > 0;
+  const hasUploadedBoundary =
+    formData?.HCM_CAMPAIGN_UPLOAD_BOUNDARY_DATA?.uploadBoundary?.uploadedFile?.length > 0;
+  const hasUploadedFacility =
+    formData?.HCM_CAMPAIGN_UPLOAD_FACILITY_DATA?.uploadFacility?.uploadedFile?.length > 0;
+  const hasUploadedUser =
+    formData?.HCM_CAMPAIGN_UPLOAD_USER_DATA?.uploadUser?.uploadedFile?.length > 0;
+  const hasUploadedUnified =
+    formData?.HCM_CAMPAIGN_UPLOAD_UNIFIED_DATA?.uploadUnified?.uploadedFile?.length > 0;
   return !!(
-    formData?.HCM_CAMPAIGN_SELECTING_BOUNDARY_DATA ||
-    formData?.HCM_CAMPAIGN_UPLOAD_BOUNDARY_DATA ||
-    formData?.HCM_CAMPAIGN_UPLOAD_FACILITY_DATA ||
-    formData?.HCM_CAMPAIGN_UPLOAD_USER_DATA ||
-    formData?.HCM_CAMPAIGN_UPLOAD_UNIFIED_DATA
+    hasBoundarySelections ||
+    hasUploadedBoundary ||
+    hasUploadedFacility ||
+    hasUploadedUser ||
+    hasUploadedUnified
   );
 };
 
@@ -163,8 +175,7 @@ const SelectHierarchy = ({ onSelect, formData, ...props }) => {
   const onHierarchySelect = (value) => {
     if (isSameHierarchy(selected, value)) return;
     const isHierarchyChanged = hierarchyValue && !isSameHierarchy(hierarchyValue, value);
-    const hasData = hasDependentData(formStorageData) || !!(formData?.SelectHierarchy?.hasBoundaryData);
-    if (isHierarchyChanged && hasData) {
+    if (isHierarchyChanged && hasDependentData(formStorageData)) {
       setPendingSelection(value);
       setShowConfirmPopup(true);
     } else {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -561,6 +561,7 @@ const MultiSelectDropdown = ({
       setIsProcessing(true);
       requestAnimationFrame(() => {
         startTransition(() => {
+          let updatedState;
           if (selectAllChecked) {
             // Only remove items that are in the current options, keep others
             const currentOptionCodesSet = new Set(
@@ -568,10 +569,10 @@ const MultiSelectDropdown = ({
                 ? flattenedOptions.filter((option) => !option.options).map((option) => option.code)
                 : options.map((option) => option.code)
             );
-            const remainingSelections = alreadyQueuedSelectedState.filter(
+            updatedState = alreadyQueuedSelectedState.filter(
               (selected) => !currentOptionCodesSet.has(selected.code) || frozenCodesSet.has(selected.code)
             );
-            dispatch({ type: "REPLACE_COMPLETE_STATE", payload: remainingSelections });
+            dispatch({ type: "REPLACE_COMPLETE_STATE", payload: updatedState });
             setSelectAllChecked(false);
           } else {
             // Build the new selections from current options
@@ -594,17 +595,17 @@ const MultiSelectDropdown = ({
               propsData: [null, option],
             }));
 
-            const mergedPayload = [...existingSelections, ...newPayload];
+            updatedState = [...existingSelections, ...newPayload];
 
             dispatch({
               type: "REPLACE_COMPLETE_STATE",
-              payload: mergedPayload,
+              payload: updatedState,
             });
             setSelectAllChecked(true);
           }
           setIsProcessing(false);
           onSelect(
-            alreadyQueuedSelectedState?.map((e) => e.propsData),
+            updatedState?.map((e) => e.propsData),
             getCategorySelectAllState(),
             props
           );

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/SelectingBoundaryComponent.js
@@ -271,7 +271,12 @@ const SelectingBoundaryComponent = ({
           if (frozenData?.length > 0) {
             const mergedFrozenData = [...(selectedData || []).filter((item) => item?.type !== newBoundaryType), ...transformedRes];
             const mergedCodes = new Set(mergedFrozenData.map((item) => item.code));
-            mergedData = [...mergedFrozenData, ...frozenData.filter((frozenItem) => !mergedCodes.has(frozenItem.code))];
+            // Only re-add frozen items that are still in the current selectedData.
+            // Items the user explicitly cleared (by clearing a parent) should stay cleared.
+            const currentSelectedCodes = new Set((selectedData || []).map((item) => item.code));
+            mergedData = [...mergedFrozenData, ...frozenData.filter((frozenItem) =>
+              !mergedCodes.has(frozenItem.code) && currentSelectedCodes.has(frozenItem.code)
+            )];
           } else {
             mergedData = [...(selectedData || []).filter((item) => item?.type !== newBoundaryType), ...transformedRes];
           }

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/commodityCampaignConfig.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/configs/commodityCampaignConfig.js
@@ -26,12 +26,6 @@ const createTabConfig = (label, moduleName) => ({
         defaultValues: {
           campaignName: "",
         },
-        sortConfig: {
-          initialSortOrder: "desc",
-          label: "SORT",
-          variation: "teritiary",
-          icon: "ImportExport",
-        },
         fields: [
           {
             label: "CAMPAIGN_SEARCH_NAME",

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/CycleConfiguration.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/CycleConfiguration.js
@@ -354,9 +354,13 @@ function CycleConfiguration({ onSelect, formData, control, ...props }) {
         <div className="card-container2">
           <div style={{ marginBottom: "1.5rem" }}>
             <Card>
-              {tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate && tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate && (
-                <TagComponent campaignName={`${convertEpochToNewDateFormat(tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate)} - ${convertEpochToNewDateFormat(tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate)}`} />
-              )}
+              {dateRange?.startDate && dateRange?.endDate && (() => {
+                const startFormatted = convertEpochToNewDateFormat(dateRange.startDate);
+                const endFormatted = convertEpochToNewDateFormat(dateRange.endDate);
+                return startFormatted && endFormatted ? (
+                  <TagComponent campaignName={`${startFormatted} - ${endFormatted}`} />
+                ) : null;
+              })()}
               <HeaderComponent className="cycle-configuration-heading">
                 {t(`CAMPAIGN_PROJECT_${selectedProjectType.toUpperCase()}`)}
               </HeaderComponent>

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/CycleConfiguration.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/CycleConfiguration.js
@@ -113,7 +113,6 @@ function CycleConfiguration({ onSelect, formData, control, ...props }) {
   const campaignNumber = searchParams.get("campaignNumber");
   const selectedProjectType =
     formStorageData?.HCM_CAMPAIGN_TYPE?.projectType?.code || searchParams.get("projectType");
-  const campaignName = formStorageData?.HCM_CAMPAIGN_NAME?.campaignName;
   const [filteredDeliveryConfig, setFilterDeliveryConfig] = useState(null);
   const { isLoading: deliveryConfigLoading, data } = Digit.Hooks.useCustomMDMS(
     tenantId,
@@ -355,18 +354,12 @@ function CycleConfiguration({ onSelect, formData, control, ...props }) {
         <div className="card-container2">
           <div style={{ marginBottom: "1.5rem" }}>
             <Card>
-              <TagComponent campaignName={campaignName} />
+              {tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate && tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate && (
+                <TagComponent campaignName={`${convertEpochToNewDateFormat(tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate)} - ${convertEpochToNewDateFormat(tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate)}`} />
+              )}
               <HeaderComponent className="cycle-configuration-heading">
                 {t(`CAMPAIGN_PROJECT_${selectedProjectType.toUpperCase()}`)}
               </HeaderComponent>
-              {tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate && tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate && (
-                <p className="dates-description" style={{margin:"0rem"}}>
-                  {`${convertEpochToNewDateFormat(tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.startDate)} - ${convertEpochToNewDateFormat(
-                    tempSession?.HCM_CAMPAIGN_DATE?.campaignDates?.endDate
-                  )}`}
-                </p>
-              )}
-              <CardText style={{fontSize:"19px",color:"#505a5f"}}>{t(`CAMPAIGN_CYCLE_CONFIGURE_HEADING_${selectedProjectType.toUpperCase()}`)}</CardText>
               <LabelFieldPair>
                 <CardLabel className="cycleBold" style={{ fontWeight: "700",width:"40%" }}>
                   {t(I18N_KEYS.PAGES.CAMPAIGN_NO_OF_CYCLE)}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -9,11 +9,13 @@ import { transformCreateData } from "../../../utils/transformCreateData";
 import { handleCreateValidate } from "../../../utils/handleCreateValidate";
 import { I18N_KEYS } from "../../../utils/i18nKeyConstants";
 import useCampaignStore from "../../../hooks/useCampaignStore";
-import { resetAllCampaignData, clearSelectedHierarchy, clearSelectedHierarchyCode } from "../../../store/campaignStore";
+import { resetAllCampaignData, resetCreateCampaignData, clearSelectedHierarchy, clearSelectedHierarchyCode } from "../../../store/campaignStore";
 import { useDispatch } from "react-redux";
+import { useLocation } from "react-router-dom";
 const CreateCampaign = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const tenantId = Digit.ULBService.getCurrentTenantId();
   const [showToast, setShowToast] = useState(null);
   const [totalFormData, setTotalFormData] = useState({});
@@ -164,13 +166,16 @@ const CreateCampaign = () => {
     setTotalFormData(params);
   }, [params]);
 
+  // Reset all campaign state when entering for a new campaign (no id).
+  // location.key changes on every navigation, ensuring this runs even if
+  // the component stays mounted across back/forward navigations.
   useEffect(() => {
-    if (!id) {
-      dispatch(clearSelectedHierarchy());
-      dispatch(clearSelectedHierarchyCode());
-      setParams({});  // Clear stale campaign name/date/type from previous flow
+    if (!id && !editName && !fromTemplate) {
+      dispatch(resetCreateCampaignData());
+      setParams({});
+      hasLoadedDraft.current = false;
     }
-  }, []);
+  }, [location.key]);
 
   useEffect(() => {
     updateUrlParams({ key: currentKey });

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/NewCampaignCreate/CreateCampaign.js
@@ -9,8 +9,7 @@ import { transformCreateData } from "../../../utils/transformCreateData";
 import { handleCreateValidate } from "../../../utils/handleCreateValidate";
 import { I18N_KEYS } from "../../../utils/i18nKeyConstants";
 import useCampaignStore from "../../../hooks/useCampaignStore";
-import { resetAllCampaignData, resetCreateCampaignData, clearSelectedHierarchy, clearSelectedHierarchyCode } from "../../../store/campaignStore";
-import { useDispatch } from "react-redux";
+import { resetAllCampaignData, resetCreateCampaignData, clearSelectedHierarchy, clearSelectedHierarchyCode, campaignStore } from "../../../store/campaignStore";
 import { useLocation } from "react-router-dom";
 const CreateCampaign = () => {
   const { t } = useTranslation();
@@ -25,7 +24,6 @@ const CreateCampaign = () => {
   const fromTemplate = searchParams.get("fromTemplate");
   const [params, setParams] = useCampaignStore("HCM_ADMIN_CONSOLE_DATA", {});
   const [storedHierarchy] = useCampaignStore("HCM_CAMPAIGN_SELECTED_HIERARCHY", null);
-  const dispatch = useDispatch();
   const [campaignConfig, setCampaignConfig] = useState(CampaignCreateConfig(totalFormData, editName, fromTemplate));
   const [loader, setLoader] = useState(null);
   const skip = searchParams.get("skip");
@@ -170,8 +168,8 @@ const CreateCampaign = () => {
   // location.key changes on every navigation, ensuring this runs even if
   // the component stays mounted across back/forward navigations.
   useEffect(() => {
-    if (!id && !editName && !fromTemplate) {
-      dispatch(resetCreateCampaignData());
+    if (!id && !searchParams.get("campaignNumber") && !editName && !fromTemplate) {
+      campaignStore.dispatch(resetCreateCampaignData());
       setParams({});
       hasLoadedDraft.current = false;
     }
@@ -250,7 +248,7 @@ const CreateCampaign = () => {
   };
 
   const cleanupSessionAndNavigate = (campNumber, campTenantId) => {
-    dispatch(resetAllCampaignData());
+    campaignStore.dispatch(resetAllCampaignData());
     const baseUrl = `/${window.contextPath}/employee/campaign/view-details?campaignNumber=${campNumber}&tenantId=${campTenantId}`;
     navigate(isDraft === "true" ? `${baseUrl}&draft=true` : baseUrl);
   };

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/AddDeliverycontext.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/AddDeliverycontext.js
@@ -163,11 +163,12 @@ const AddAttributeField = React.memo(({
     let val = e.target.value;
     val = val.replace(/[^\d.]/g, "");
     val = val.match(/^\d*\.?\d{0,2}/)[0] || "";
-    
+
     if (isNaN(val) || [" ", "e", "E"].some(f => val.includes(f))) {
       return;
     }
-    
+    if (val.length > 10) return;
+
     updateAttributeField(rule.ruleKey, attribute.key, 'value', val);
   }, [updateAttributeField, rule.ruleKey, attribute.key]);
 
@@ -179,11 +180,12 @@ const AddAttributeField = React.memo(({
     let val = e.target.value;
     val = val.replace(/[^\d.]/g, "");
     val = val.match(/^\d*\.?\d{0,2}/)[0] || "";
-    
+
     if (isNaN(val) || [" ", "e", "E"].some(f => val.includes(f))) {
       return;
     }
-    
+    if (val.length > 10) return;
+
     const field = range === "to" ? "toValue" : "fromValue";
     updateAttributeField(rule.ruleKey, attribute.key, field, val);
   }, [updateAttributeField, rule.ruleKey, attribute.key]);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/MultiTabcontext.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/MultiTabcontext.js
@@ -78,7 +78,6 @@ const MultiTab = React.memo(({ projectConfig, attributeConfig, operatorConfig, d
   // Get session data for display
   const tempSession = useMemo(() => formStorageData || {}, [formStorageData, projectConfig]);
 
-  const campaignName = tempSession?.HCM_CAMPAIGN_NAME?.campaignName;
   const projectType = tempSession?.HCM_CAMPAIGN_TYPE?.projectType || projectConfig?.code;
   const campaignDates = tempSession?.HCM_CAMPAIGN_DATE?.campaignDates;
 
@@ -102,15 +101,13 @@ const MultiTab = React.memo(({ projectConfig, attributeConfig, operatorConfig, d
   return (
     <div className="container-full">
       <div className="card-container-delivery">
-        {campaignName && <TagComponent campaignName={campaignName} />}
+        {formattedDates && <TagComponent campaignName={formattedDates} />}
 
         {projectTitle && (
           <HeaderComponent styles={{ marginTop: "1.5rem" }} className="select-boundary-screen-heading">
             {t(projectTitle)}
           </HeaderComponent>
         )}
-
-        {formattedDates && <Paragraph customClassName="cycle-paragraph" value={formattedDates} />}
 
         <div className="campaign-cycle-container">
           <div className="campaign-tabs-container">

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/MultiTabcontext.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/MultiTabcontext.js
@@ -89,6 +89,7 @@ const MultiTab = React.memo(({ projectConfig, attributeConfig, operatorConfig, d
 
     const startDate = convertEpochToNewDateFormat(campaignDates.startDate);
     const endDate = convertEpochToNewDateFormat(campaignDates.endDate);
+    if (!startDate || !endDate) return "";
     return `${startDate} - ${endDate}`;
   }, [campaignDates]);
 

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/deliveryRulesSlice.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/deliveryRulesSlice.js
@@ -2,6 +2,7 @@ import { createSlice, createSelector } from '@reduxjs/toolkit';
 
 const initialState = {
   campaignData: [],
+  campaignId: null,
   activeTabIndex: 0,
   activeSubTabIndex: 0,
   loading: false,
@@ -14,10 +15,11 @@ const deliveryRulesSlice = createSlice({
   initialState,
   reducers: {
     initializeCampaignData: (state, action) => {
-      const { cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig } = action.payload;
+      const { cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig, campaignId } = action.payload;
 
       // Always reset the state to ensure clean initialization
       state.campaignData = [];
+      state.campaignId = campaignId || null;
       state.activeTabIndex = 0;
       state.activeSubTabIndex = 0;
       state.error = null;
@@ -53,6 +55,7 @@ const deliveryRulesSlice = createSlice({
     
     resetCampaignData: (state) => {
       state.campaignData = [];
+      state.campaignId = null;
       state.activeTabIndex = 0;
       state.activeSubTabIndex = 0;
       state.initialized = false;
@@ -629,6 +632,7 @@ function generateInitialAttributes(attributeConfigFromProject, globalAttributeCo
 }
 // Selectors
 export const selectCampaignData = (state) => state.deliveryRules.campaignData;
+export const selectCampaignId = (state) => state.deliveryRules.campaignId;
 export const selectActiveTabIndex = (state) => state.deliveryRules.activeTabIndex;
 export const selectActiveSubTabIndex = (state) => state.deliveryRules.activeSubTabIndex;
 export const selectLoading = (state) => state.deliveryRules.loading;

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/index.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/index.js
@@ -34,6 +34,7 @@ const DeliverySetupContainer = ({ onSelect, config, formData, control, tabCount 
 
   const {
     campaignData,
+    storedCampaignId,
     initializeData,
     initialized,
     loading: storeLoading,
@@ -129,6 +130,17 @@ const DeliverySetupContainer = ({ onSelect, config, formData, control, tabCount 
     prevCampaignIdRef.current = currentCampaignId;
   }, [selectedProjectType, currentCampaignId, resetData]);
 
+  // If the Redux store holds data for a different campaign, reset it so
+  // the initialization effect below can run fresh for the current campaign.
+  useEffect(() => {
+    if (initialized && currentCampaignId && storedCampaignId && storedCampaignId !== currentCampaignId) {
+      resetData();
+      hasInitialSyncRef.current = false;
+      prevCycleCountRef.current = null;
+      prevDeliveryCountRef.current = null;
+    }
+  }, [initialized, currentCampaignId, storedCampaignId, resetData]);
+
   // Initialize campaign data when dependencies are ready
   useEffect(() => {
     if (!cycleData?.cycleConfgureDate || !effectiveDeliveryConfig) {
@@ -147,12 +159,12 @@ const DeliverySetupContainer = ({ onSelect, config, formData, control, tabCount 
     }
 
     try {
-      initializeData(cycles, deliveries, effectiveDeliveryConfig, savedDeliveryRules, attributeConfigRef.current, operatorConfigRef.current);
+      initializeData(cycles, deliveries, effectiveDeliveryConfig, savedDeliveryRules, attributeConfigRef.current, operatorConfigRef.current, currentCampaignId);
     } catch (error) {
       console.error('Error initializing campaign data:', error);
       setErrorState(error.message);
     }
-  }, [cycleData, effectiveDeliveryConfig, initialized, initializeData, savedDeliveryRules, setErrorState]);
+  }, [cycleData, effectiveDeliveryConfig, initialized, initializeData, savedDeliveryRules, setErrorState, currentCampaignId]);
 
   // Perform initial sync after initialization to handle saved data with different counts
   useEffect(() => {
@@ -289,12 +301,9 @@ const DeliverySetupContainer = ({ onSelect, config, formData, control, tabCount 
     }
   }, [dataError, setErrorState]);
 
-  // Clean up on unmount
-  useEffect(() => {
-    return () => {
-      resetData();
-    };
-  }, [resetData]);
+  // No unmount cleanup — the module-level Redux store persists across navigations
+  // (e.g. navigating to add-product and back). Stale data for a different campaign
+  // is handled by the campaign ID comparison effect above.
 
   // Counteract Dropdown components' built-in scrollIntoView({behavior:"smooth"})
   // that fires on mount when the element is below the viewport.

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/index.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/index.js
@@ -133,7 +133,7 @@ const DeliverySetupContainer = ({ onSelect, config, formData, control, tabCount 
   // If the Redux store holds data for a different campaign, reset it so
   // the initialization effect below can run fresh for the current campaign.
   useEffect(() => {
-    if (initialized && currentCampaignId && storedCampaignId && storedCampaignId !== currentCampaignId) {
+    if (initialized && storedCampaignId && storedCampaignId !== currentCampaignId) {
       resetData();
       hasInitialSyncRef.current = false;
       prevCycleCountRef.current = null;

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/useDeliveryRules.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/pages/employee/deliveryRule/useDeliveryRules.js
@@ -2,6 +2,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useCallback, useEffect, useMemo } from 'react';
 import {
   selectCampaignData,
+  selectCampaignId,
   selectActiveTabIndex,
   selectActiveSubTabIndex,
   selectActiveCycle,
@@ -35,6 +36,7 @@ export const useDeliveryRules = () => {
   const dispatch = useDispatch();
 
   const campaignData = useSelector(selectCampaignData);
+  const storedCampaignId = useSelector(selectCampaignId);
   const activeTabIndex = useSelector(selectActiveTabIndex);
   const activeSubTabIndex = useSelector(selectActiveSubTabIndex);
   const activeCycle = useSelector(selectActiveCycle);
@@ -45,8 +47,8 @@ export const useDeliveryRules = () => {
   const initialized = useSelector(selectInitialized);
 
 
-  const initializeData = useCallback((cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig) => {
-    dispatch(initializeCampaignData({ cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig }));
+  const initializeData = useCallback((cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig, campaignId) => {
+    dispatch(initializeCampaignData({ cycles, deliveries, effectiveDeliveryConfig, savedData, attributeConfig, operatorConfig, campaignId }));
   }, [dispatch]);
 
   const changeTab = useCallback((tabIndex) => {
@@ -154,6 +156,7 @@ export const useDeliveryRules = () => {
   return {
     // State
     campaignData,
+    storedCampaignId,
     activeTabIndex,
     activeSubTabIndex,
     activeCycle,


### PR DESCRIPTION
## Summary

- **Hierarchy selection popup fix**: Popup now only appears when campaign-specific data (boundary selections or uploaded files) actually exists. Previously, stale IndexedDB keys from prior sessions caused false positives, and system-level boundary existence was incorrectly used as a trigger.
- **Delivery rules persistence**: Removed unmount cleanup that was resetting Redux state when navigating away (e.g., to add-product page). Added `campaignId` tracking in the delivery rules slice to auto-reset stale data from a different campaign instead.
- **Stale campaign state reset**: `CreateCampaign.js` now uses `location.key` to detect fresh navigations and calls `resetCreateCampaignData()`, preventing data from a previous campaign leaking into a new one.
- **CycleSelection MDMS-driven roundTypes**: Round type radio buttons (Single/Multi Round) are now controlled by the `roundTypes` key in the project type MDMS config, instead of being always disabled.
- **Campaign name 30-char limit**: Hard limit enforced in both `CampaignName.js` and `CampaignNameInput.js` onChange handlers.
- **Delivery rule value 10-char limit**: Prevents unreasonable entries in attribute value and range inputs.
- **Dates tag replaces campaign name tag**: `CycleConfiguration` and `MultiTabcontext` now show campaign dates as the tag instead of campaign name.
- **Commodity inbox sort icon removed**: Removed `sortConfig` from `commodityCampaignConfig.js`.
- **ComponentToRender defaultValue preview**: Shows default value in the form builder preview for field types where `visibilityEnabledFor` includes them (numeric, number, mobileNumber), driven by MDMS `FieldPropertiesPanelConfig`.

## Files Changed (13)

| File | Change |
|------|--------|
| `CampaignName.js` | 30-char limit |
| `CampaignNameInput.js` | 30-char limit |
| `ComponentToRender.js` | Default value preview from MDMS |
| `CycleSelection.js` | MDMS-driven roundTypes |
| `SelectHierarchy.js` | Hierarchy popup false-positive fix |
| `commodityCampaignConfig.js` | Removed sort icon config |
| `CycleConfiguration.js` | Dates tag replacing campaign name |
| `CreateCampaign.js` | Stale state reset via location.key |
| `AddDeliverycontext.js` | 10-char value limit |
| `MultiTabcontext.js` | Dates tag replacing campaign name |
| `deliveryRulesSlice.js` | campaignId tracking in Redux |
| `deliveryRule/index.js` | Removed unmount reset, added campaignId check |
| `useDeliveryRules.js` | Exposed storedCampaignId |

## Test plan

- [ ] Create a new campaign from scratch — verify no stale data from previous campaigns
- [ ] On hierarchy selection (key=4), switch hierarchy types — popup should NOT appear for a fresh campaign with no boundaries
- [ ] Select boundaries, go back to hierarchy — popup SHOULD appear
- [ ] Configure delivery rules, navigate to add-product page and back — rules should persist
- [ ] Open a different campaign's delivery rules — stale rules from previous campaign should be cleared
- [ ] Verify campaign name input enforces 30-char max
- [ ] Verify delivery rule value inputs enforce 10-char max
- [ ] Check CycleSelection radio buttons respect roundTypes from MDMS project type
- [ ] Verify dates tag (not campaign name) appears on cycle config and delivery rules pages
- [ ] In form builder, set defaultValue on a numeric field — preview should show the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Campaign names now support up to 30 characters.
  - Numeric delivery-rule values support up to 10 characters.
  - Cycle options now reflect the selected campaign type and automatically choose a valid option.
  - Field previews can display applicable numeric default values.

- **Bug Fixes**
  - Prevented stale delivery-rule data from carrying over between campaigns.
  - Improved confirmation handling when changing hierarchies with existing selections or uploads.
  - Campaign creation state now resets correctly when navigating between new campaigns.

- **UI Updates**
  - Campaign dates are displayed consistently in configuration and delivery-rule views.
  - Removed campaign-name labels and search sorting controls where no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->