### PR TITLE
BUGFIX/HCMPRE-3660 : Paginated facility search, stock table cleanup, and dropdown styling fixes

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/BulkStockUpload.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/BulkStockUpload.js
@@ -7,6 +7,7 @@ import StockComponent from "./StockComponent";
 import BulkUpload from "../BulkUpload";
 import XLSX from "xlsx";
 import useBatchStockCreation from "../../hooks/useBatchStockCreation";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const BulkStockUpload = () => {
   const { t } = useTranslation();
@@ -394,12 +395,13 @@ const BulkStockUpload = () => {
   // Fetch ALL project facilities to know which projects have facilities
   const allFacilityReqCriteria = useMemo(() => ({
     url: `/${projectServicePath}/facility/v1/_search`,
-    params: { tenantId: tenantId, limit: 1000, offset: 0 },
+    params: { tenantId: tenantId },
     body: {
       ProjectFacility: {
         projectId: allProjectIds,
       },
     },
+    dataKey: "ProjectFacilities",
     config: {
       enabled: !!allProjectIds?.length,
       select: (data) => {
@@ -413,7 +415,7 @@ const BulkStockUpload = () => {
     },
   }), [tenantId, allProjectIds]);
 
-  const { data: projectIdsWithFacilities, isLoading: allFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(allFacilityReqCriteria);
+  const { data: projectIdsWithFacilities, isLoading: allFacilitiesLoading } = usePaginatedSearch(allFacilityReqCriteria);
 
   // Build hierarchy filter options only from projects that have facilities
   const hierarchyFilterOptions = useMemo(() => {
@@ -525,12 +527,13 @@ const BulkStockUpload = () => {
   // Fetch "From" facilities
   const fromFacilityReqCriteria = useMemo(() => ({
     url: `/${projectServicePath}/facility/v1/_search`,
-    params: { tenantId: tenantId, limit: 1000, offset: 0 },
+    params: { tenantId: tenantId },
     body: {
       ProjectFacility: {
         projectId: fromFilteredProjectIds,
       },
     },
+    dataKey: "ProjectFacilities",
     config: {
       enabled: !!fromFilteredProjectIds?.length,
       select: (data) => {
@@ -548,7 +551,7 @@ const BulkStockUpload = () => {
     },
   }), [tenantId, fromFilteredProjectIds]);
 
-  const { data: rawFromFacilityList, isLoading: fromFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(fromFacilityReqCriteria);
+  const { data: rawFromFacilityList, isLoading: fromFacilitiesLoading } = usePaginatedSearch(fromFacilityReqCriteria);
 
   // Enrich From facilities with boundary level info
   const fromFacilityList = useMemo(() => {
@@ -562,12 +565,13 @@ const BulkStockUpload = () => {
   // Fetch "To" facilities
   const toFacilityReqCriteria = useMemo(() => ({
     url: `/${projectServicePath}/facility/v1/_search`,
-    params: { tenantId: tenantId, limit: 1000, offset: 0 },
+    params: { tenantId: tenantId },
     body: {
       ProjectFacility: {
         projectId: toFilteredProjectIds,
       },
     },
+    dataKey: "ProjectFacilities",
     config: {
       enabled: !!toFilteredProjectIds?.length,
       select: (data) => {
@@ -585,7 +589,7 @@ const BulkStockUpload = () => {
     },
   }), [tenantId, toFilteredProjectIds]);
 
-  const { data: rawToFacilityList, isLoading: toFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(toFacilityReqCriteria);
+  const { data: rawToFacilityList, isLoading: toFacilitiesLoading } = usePaginatedSearch(toFacilityReqCriteria);
 
   // Enrich To facilities with boundary level info
   const toFacilityList = useMemo(() => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityShipmentPopup.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityShipmentPopup.js
@@ -13,6 +13,7 @@ import {
 } from "@egovernments/digit-ui-components";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
 import { useCommodityProject } from "./CommodityProjectContext";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const COMMODITY_KEYS = I18N_KEYS.COMMODITY_MANAGEMENT;
 
@@ -96,8 +97,9 @@ const CommodityShipmentPopup = ({
   const facilityMappingCriteria = useMemo(
     () => ({
       url: `/${projectServicePath}/facility/v1/_search`,
-      params: { tenantId, limit: 1000, offset: 0 },
+      params: { tenantId },
       body: { ProjectFacility: { projectId: toProjectIds } },
+      dataKey: "ProjectFacilities",
       config: {
         enabled: !!toProjectIds?.length,
         select: (data) => {
@@ -120,7 +122,7 @@ const CommodityShipmentPopup = ({
     }),
     [tenantId, toProjectIds],
   );
-  const { data: facilityMappingData, isLoading: facilityMappingLoading } = Digit.Hooks.useCustomAPIHook(
+  const { data: facilityMappingData, isLoading: facilityMappingLoading } = usePaginatedSearch(
     facilityMappingCriteria,
   );
   const facilityToProject = facilityMappingData?.facilityToProject || {};
@@ -130,12 +132,9 @@ const CommodityShipmentPopup = ({
   const facilityDetailsCriteria = useMemo(
     () => ({
       url: `/facility/v1/_search`,
-      params: {
-        tenantId,
-        limit: toFacilityIds.length || 10,
-        offset: 0,
-      },
+      params: { tenantId },
       body: { Facility: { id: toFacilityIds } },
+      dataKey: "Facilities",
       config: {
         enabled: !!toFacilityIds.length && !!tenantId,
         select: (data) => {
@@ -148,7 +147,7 @@ const CommodityShipmentPopup = ({
     }),
     [tenantId, toFacilityIds],
   );
-  const { data: toFacilitiesList = [], isLoading: facilityDetailsLoading } = Digit.Hooks.useCustomAPIHook(
+  const { data: toFacilitiesList = [], isLoading: facilityDetailsLoading } = usePaginatedSearch(
     facilityDetailsCriteria,
   );
 

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/NewShipmentPopup.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/NewShipmentPopup.js
@@ -14,6 +14,7 @@ import {
 } from "@egovernments/digit-ui-components";
 import BulkUpload from "../BulkUpload";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const NewShipmentPopup = ({
   campaignNumber,
@@ -463,8 +464,9 @@ const NewShipmentPopup = ({
   const fromFacilityReqCriteria = useMemo(
     () => ({
       url: `/${projectServicePath}/facility/v1/_search`,
-      params: { tenantId, limit: 1000, offset: 0 },
+      params: { tenantId },
       body: { ProjectFacility: { projectId: fromFilteredProjectIds } },
+      dataKey: "ProjectFacilities",
       config: {
         enabled: !!fromFilteredProjectIds?.length,
         staleTime: 0,
@@ -489,14 +491,15 @@ const NewShipmentPopup = ({
   const {
     data: fromFacilityList,
     isLoading: fromFacilitiesLoading,
-  } = Digit.Hooks.useCustomAPIHook(fromFacilityReqCriteria);
+  } = usePaginatedSearch(fromFacilityReqCriteria);
 
   // Fetch "To" facilities using filtered project IDs
   const toFacilityReqCriteria = useMemo(
     () => ({
       url: `/${projectServicePath}/facility/v1/_search`,
-      params: { tenantId, limit: 1000, offset: 0 },
+      params: { tenantId },
       body: { ProjectFacility: { projectId: toFilteredProjectIds } },
+      dataKey: "ProjectFacilities",
       config: {
         enabled: !!toFilteredProjectIds?.length,
         select: (data) => {
@@ -519,7 +522,7 @@ const NewShipmentPopup = ({
   const {
     data: rawToFacilityList,
     isLoading: toFacilitiesLoading,
-  } = Digit.Hooks.useCustomAPIHook(toFacilityReqCriteria);
+  } = usePaginatedSearch(toFacilityReqCriteria);
 
   // Collect all unique facility IDs from both lists for name resolution
   const allFacilityIds = useMemo(() => {
@@ -532,8 +535,9 @@ const NewShipmentPopup = ({
   // Fetch facility details to get names
   const facilityNameSearchCriteria = useMemo(() => ({
     url: `/facility/v1/_search`,
-    params: { tenantId, limit: allFacilityIds.length || 10, offset: 0 },
+    params: { tenantId },
     body: { Facility: { id: allFacilityIds } },
+    dataKey: "Facilities",
     config: {
       enabled: !!allFacilityIds.length && !!tenantId,
       select: (data) => {
@@ -546,7 +550,7 @@ const NewShipmentPopup = ({
     },
   }), [tenantId, allFacilityIds]);
 
-  const { data: facilityNameMap = {}, isLoading: facilityNamesLoading } = Digit.Hooks.useCustomAPIHook(facilityNameSearchCriteria);
+  const { data: facilityNameMap = {}, isLoading: facilityNamesLoading } = usePaginatedSearch(facilityNameSearchCriteria);
 
   // Enrich facility lists with resolved names (dedup by id as safety net)
   const enrichedFromFacilityList = useMemo(() => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/PendingTransactionsTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/PendingTransactionsTab.js
@@ -7,6 +7,7 @@ import GenericChart from "./GenericChart";
 import UserDetails from "./UserDetails";
 import getProjectServiceUrl from "../../utils/getProjectServiceUrl";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const PendingTransactionsTab = ({
   rawStockData,
@@ -30,8 +31,9 @@ const PendingTransactionsTab = ({
   const projectFacilityCriteria = useMemo(
     () => ({
       url: `${getProjectServiceUrl()}/facility/v1/_search`,
-      params: { tenantId, limit: 100, offset: 0 },
+      params: { tenantId },
       body: { ProjectFacility: { projectId: [projectId] } },
+      dataKey: "ProjectFacilities",
       config: {
         enabled: !!projectId && !!tenantId,
         select: (data) => {
@@ -46,7 +48,7 @@ const PendingTransactionsTab = ({
     [tenantId, projectId]
   );
   const { data: projectFacilityIds = new Set(), isLoading: projectFacilitiesLoading } =
-    Digit.Hooks.useCustomAPIHook(projectFacilityCriteria);
+    usePaginatedSearch(projectFacilityCriteria);
 
   // Extract unique facility IDs and product variant IDs from stock data
   const { facilityIds, productVariantIds } = useMemo(() => {
@@ -65,8 +67,9 @@ const PendingTransactionsTab = ({
   const facilitySearchCriteria = useMemo(
     () => ({
       url: `/facility/v1/_search`,
-      params: { tenantId, limit: facilityIds.length || 10, offset: 0 },
+      params: { tenantId },
       body: { Facility: { id: facilityIds } },
+      dataKey: "Facilities",
       config: {
         enabled: !!facilityIds.length && !!tenantId,
         select: (data) => {
@@ -91,7 +94,7 @@ const PendingTransactionsTab = ({
     [tenantId, facilityIds]
   );
   const { data: facilityNameMap = {}, isLoading: facilitiesLoading } =
-    Digit.Hooks.useCustomAPIHook(facilitySearchCriteria);
+    usePaginatedSearch(facilitySearchCriteria);
 
   // Fetch product variants
   const variantSearchCriteria = useMemo(

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/StockSummaryTab.js
@@ -9,6 +9,7 @@ import GenericChart from "./GenericChart";
 import CommodityShipmentPopup from "./CommodityShipmentPopup";
 import getProjectServiceUrl from "../../utils/getProjectServiceUrl";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const toCamelCase = (str) =>
   str.split(" ")
@@ -42,8 +43,9 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
   // Fetch facility details by IDs (name + usage/type)
   const facilitySearchCriteria = useMemo(() => ({
     url: `/facility/v1/_search`,
-    params: { tenantId, limit: facilityIds.length || 10, offset: 0 },
+    params: { tenantId },
     body: { Facility: { id: facilityIds } },
+    dataKey: "Facilities",
     config: {
       enabled: !!facilityIds.length && !!tenantId,
       select: (data) => {
@@ -74,7 +76,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
       },
     },
   }), [tenantId, facilityIds]);
-  const { data: facilityMaps, isLoading: facilitiesLoading } = Digit.Hooks.useCustomAPIHook(facilitySearchCriteria);
+  const { data: facilityMaps, isLoading: facilitiesLoading } = usePaginatedSearch(facilitySearchCriteria);
   const facilityNameMap = facilityMaps?.nameMap || {};
 
 
@@ -150,8 +152,9 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
   // Fetch project facilities using the selected project (not derived from context)
   const projectFacilityCriteria = useMemo(() => ({
     url: `${getProjectServiceUrl()}/facility/v1/_search`,
-    params: { tenantId, limit: 100, offset: 0 },
+    params: { tenantId },
     body: { ProjectFacility: { projectId: [projectId] } },
+    dataKey: "ProjectFacilities",
     config: {
       enabled: !!projectId && !!tenantId,
       select: (data) => {
@@ -163,7 +166,7 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
       },
     },
   }), [tenantId, projectId]);
-  const { data: userFacilityIds = new Set(), isLoading: projectFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(projectFacilityCriteria);
+  const { data: userFacilityIds = new Set(), isLoading: projectFacilitiesLoading } = usePaginatedSearch(projectFacilityCriteria);
 
   // User's own facility: first project facility (primary facility for shipment actions)
   const userOwnFacilityId = useMemo(() => {
@@ -579,7 +582,6 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
     { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_TOTAL_RECEIVED), key: "totalReceived", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_TOTAL_ACCEPTED), key: "totalAccepted", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_TOTAL_ISSUED),   key: "totalIssued",   grow: 0.7, minWidth: "110px", sortable: true },
-    { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_TOTAL_REJECTED), key: "totalRejected", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_TOTAL_RETURNED), key: "totalReturned", grow: 0.7, minWidth: "110px", sortable: true },
     { label: t(I18N_KEYS.COMMODITY_MANAGEMENT.HCM_BALANCE),        key: "balance",       grow: 0.7, minWidth: "110px", sortable: true },
   ];
@@ -599,7 +601,6 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
     totalReceived: (row) => <span className="cm-cell-stock">{row.totalReceived?.toLocaleString()}</span>,
     totalAccepted: (row) => <span className="cm-cell-stock">{row.totalAccepted?.toLocaleString()}</span>,
     totalIssued:   (row) => <span className="cm-cell-stock">{row.totalIssued?.toLocaleString()}</span>,
-    totalRejected: (row) => <span className="cm-cell-stock">{row.totalRejected?.toLocaleString()}</span>,
     totalReturned: (row) => <span className="cm-cell-stock">{row.totalReturned?.toLocaleString()}</span>,
     balance: (row) => (
       <span className={`cm-cell-stock${row.balance < 0 ? " cm-balance-negative" : ""}`}>
@@ -837,7 +838,6 @@ const StockSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenantId, c
             { label: "HCM_TOTAL_RECEIVED", value: commodity.totalReceived },
             { label: "HCM_TOTAL_ACCEPTED", value: commodity.totalAccepted },
             { label: "HCM_TOTAL_ISSUED", value: commodity.totalIssued },
-            { label: "HCM_TOTAL_REJECTED", value: commodity.totalRejected },
             { label: "HCM_TOTAL_RETURNED", value: commodity.totalReturned },
             { label: "HCM_BALANCE", value: commodity.balance },
           ]}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/TransactionSummaryTab.js
@@ -9,6 +9,7 @@ import { applyGenericFilters } from "../../utils/genericFilterUtils";
 import GenericChart from "./GenericChart";
 import getProjectServiceUrl from "../../utils/getProjectServiceUrl";
 import { I18N_KEYS } from "../../utils/i18nKeyConstants";
+import usePaginatedSearch from "../../hooks/usePaginatedSearch";
 
 const transformStock = (stock, facilityNameMap = {}, productNameMap = {}) => {
   const getFieldValue = (fieldKey) => {
@@ -95,8 +96,9 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   // Fetch project facilities using the selected project (passed from CommodityDashboard)
   const projectFacilityCriteria = useMemo(() => ({
     url: `${getProjectServiceUrl()}/facility/v1/_search`,
-    params: { tenantId, limit: 100, offset: 0 },
+    params: { tenantId },
     body: { ProjectFacility: { projectId: [projectId] } },
+    dataKey: "ProjectFacilities",
     config: {
       enabled: !!projectId && !!tenantId,
       select: (data) => {
@@ -108,7 +110,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
       },
     },
   }), [tenantId, projectId]);
-  const { data: projectFacilityIds = new Set(), isLoading: projectFacilitiesLoading } = Digit.Hooks.useCustomAPIHook(projectFacilityCriteria);
+  const { data: projectFacilityIds = new Set(), isLoading: projectFacilitiesLoading } = usePaginatedSearch(projectFacilityCriteria);
 
   // Extract unique facility IDs and product variant IDs from stock data
   const { facilityIds, productVariantIds } = useMemo(() => {
@@ -126,8 +128,9 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
   // Fetch facility details by IDs and build name lookup map
   const facilitySearchCriteria = useMemo(() => ({
     url: `/facility/v1/_search`,
-    params: { tenantId, limit: facilityIds.length || 10, offset: 0 },
+    params: { tenantId },
     body: { Facility: { id: facilityIds } },
+    dataKey: "Facilities",
     config: {
       enabled: !!facilityIds.length && !!tenantId,
       select: (data) => {
@@ -154,7 +157,7 @@ const TransactionSummaryTab = ({ rawStockData, stockLoading, stockSummary, tenan
       },
     },
   }), [tenantId, facilityIds]);
-  const { data: facilityMaps, isLoading: facilitiesLoading } = Digit.Hooks.useCustomAPIHook(facilitySearchCriteria);
+  const { data: facilityMaps, isLoading: facilitiesLoading } = usePaginatedSearch(facilitySearchCriteria);
   const facilityNameMap = facilityMaps?.nameMap || {};
 
   // Fetch product variants

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/MultiSelectDropdown.js
@@ -297,8 +297,8 @@ const Menu = ({
     );
   }
 
-  // Add 2px buffer when there's only one option to prevent a sub-pixel scrollbar
-  const listHeight = Math.min(optionsToRender.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT + (optionsToRender.length === 1 ? 2 : 0);
+  // Add 2px buffer to prevent sub-pixel scrollbar when items exactly fill the container
+  const listHeight = Math.min(optionsToRender.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT + 2;
 
   const VirtualizedRow = ({ index, style }) => {
     const option = optionsToRender[index];
@@ -319,7 +319,7 @@ const Menu = ({
       );
     } else {
       return (
-        <div style={style}>
+        <div style={{ ...style, height: style.height, boxSizing: "border-box" }}>
           <MenuItem option={option} index={index} />
         </div>
       );
@@ -336,7 +336,7 @@ const Menu = ({
         itemSize={ITEM_HEIGHT}
         width="100%"
         overscanCount={OVERSCAN_COUNT}
-        style={optionsToRender.length === 1 ? { overflowX: "hidden" } : undefined}
+        style={{ overflowX: "hidden" }}
       >
         {VirtualizedRow}
       </List>
@@ -944,6 +944,8 @@ const MultiSelectDropdown = ({
         style={{
           pointerEvents: isFrozen ? "none" : "auto",
           opacity: isFrozen ? 0.6 : 1,
+          height: "100%",
+          boxSizing: "border-box",
         }}
       >
         <input
@@ -1049,7 +1051,7 @@ const MultiSelectDropdown = ({
           </div>
         </div>
         {active ? (
-          <div className="digit-multiselectdropdown-server" id="jk-dropdown-unique" style={{ overflow: "visible", maxHeight: "none", ...(ServerStyle || {}) }}>
+          <div className="digit-multiselectdropdown-server" id="jk-dropdown-unique" style={ServerStyle ? ServerStyle : {}}>
             {variant === "treemultiselect" ? (
               <TreeSelect
                 options={parentOptionsWithChildren}

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/usePaginatedSearch.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/usePaginatedSearch.js
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 const PAGE_SIZE = 1000;
@@ -12,7 +12,7 @@ const PAGE_SIZE = 1000;
  * @param {Object} params.params - URL query params (limit/offset will be managed internally)
  * @param {Object} params.body - Request body
  * @param {string} params.dataKey - Key in response containing the array (e.g. "ProjectFacilities", "Facilities")
- * @param {Object} params.config - React Query config (enabled, select, staleTime, cacheTime, etc.)
+ * @param {Object} params.config - React Query config (enabled, select, staleTime, gcTime, etc.)
  * @param {string} params.changeQueryName - Custom query key identifier
  * @returns {{ data: any, isLoading: boolean, isFetching: boolean, refetch: Function }}
  */
@@ -34,7 +34,7 @@ const usePaginatedSearch = ({
     [url, changeQueryName, stableBody, stableParams]
   );
 
-  const fetchAllPages = async () => {
+  const fetchAllPages = async ({ signal }) => {
     const allResults = [];
     let offset = 0;
     let totalCount = null;
@@ -46,6 +46,11 @@ const usePaginatedSearch = ({
     const { limit: _l, offset: _o, ...cleanParams } = parsedParams;
 
     while (true) {
+      // Abort stale pagination loops when criteria change
+      if (signal?.aborted) {
+        break;
+      }
+
       const response = await Digit.CustomService.getResponse({
         url,
         params: { ...cleanParams, limit: PAGE_SIZE, offset },
@@ -72,10 +77,12 @@ const usePaginatedSearch = ({
     return { [dataKey]: allResults, totalCount: totalCount ?? allResults.length };
   };
 
-  const { isLoading, isFetching, data, refetch } = useQuery(queryKey, fetchAllPages, {
-    cacheTime: restConfig.cacheTime ?? 1000,
+  const { isLoading, isFetching, data, refetch } = useQuery({
+    queryKey,
+    queryFn: fetchAllPages,
+    gcTime: restConfig.gcTime ?? restConfig.cacheTime ?? 1000,
     staleTime: restConfig.staleTime ?? 5000,
-    keepPreviousData: true,
+    placeholderData: keepPreviousData,
     retry: 2,
     refetchOnWindowFocus: false,
     enabled,

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/usePaginatedSearch.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/usePaginatedSearch.js
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+const PAGE_SIZE = 1000;
+
+/**
+ * Hook that fetches all pages of a search API by paginating through results
+ * using offset/limit and totalCount from the response.
+ *
+ * @param {Object} params
+ * @param {string} params.url - API endpoint
+ * @param {Object} params.params - URL query params (limit/offset will be managed internally)
+ * @param {Object} params.body - Request body
+ * @param {string} params.dataKey - Key in response containing the array (e.g. "ProjectFacilities", "Facilities")
+ * @param {Object} params.config - React Query config (enabled, select, staleTime, cacheTime, etc.)
+ * @param {string} params.changeQueryName - Custom query key identifier
+ * @returns {{ data: any, isLoading: boolean, isFetching: boolean, refetch: Function }}
+ */
+const usePaginatedSearch = ({
+  url,
+  params: queryParams = {},
+  body = {},
+  dataKey,
+  config = {},
+  changeQueryName = "PaginatedSearch",
+}) => {
+  const { select, enabled = true, ...restConfig } = config;
+
+  const stableBody = useMemo(() => JSON.stringify(body), [body]);
+  const stableParams = useMemo(() => JSON.stringify(queryParams), [queryParams]);
+
+  const queryKey = useMemo(
+    () => ["paginated", url, changeQueryName, stableBody, stableParams],
+    [url, changeQueryName, stableBody, stableParams]
+  );
+
+  const fetchAllPages = async () => {
+    const allResults = [];
+    let offset = 0;
+    let totalCount = null;
+
+    const parsedParams = JSON.parse(stableParams);
+    const parsedBody = JSON.parse(stableBody);
+
+    // Remove any caller-provided limit/offset since we manage them
+    const { limit: _l, offset: _o, ...cleanParams } = parsedParams;
+
+    while (true) {
+      const response = await Digit.CustomService.getResponse({
+        url,
+        params: { ...cleanParams, limit: PAGE_SIZE, offset },
+        body: parsedBody,
+      });
+
+      const pageData = response?.[dataKey] || [];
+      allResults.push(...pageData);
+
+      // Get totalCount from first response
+      if (totalCount === null) {
+        totalCount = response?.totalCount ?? response?.TotalCount ?? pageData.length;
+      }
+
+      offset += PAGE_SIZE;
+
+      // Stop if we've fetched all records or got an empty page
+      if (pageData.length < PAGE_SIZE || allResults.length >= totalCount) {
+        break;
+      }
+    }
+
+    // Reconstruct the response shape so `select` functions work as before
+    return { [dataKey]: allResults, totalCount: totalCount ?? allResults.length };
+  };
+
+  const { isLoading, isFetching, data, refetch } = useQuery(queryKey, fetchAllPages, {
+    cacheTime: restConfig.cacheTime ?? 1000,
+    staleTime: restConfig.staleTime ?? 5000,
+    keepPreviousData: true,
+    retry: 2,
+    refetchOnWindowFocus: false,
+    enabled,
+    select,
+    ...restConfig,
+  });
+
+  return { data, isLoading, isFetching, refetch };
+};
+
+export default usePaginatedSearch;


### PR DESCRIPTION
## Summary
- Added `usePaginatedSearch` hook that fetches API results in batches of 1000 using `totalCount` from the response, replacing hardcoded limit values across CommodityManagement components
- Removed Total Rejected column from stock summary table and summary cards
- Reverted MultiSelectDropdown conditional 2px buffer and overflow styles back to unconditional application
- Fixed gap between MultiSelectDropdown options by making menu items fill the full virtualized row height

## Test plan
- [ ] Verify facility search works correctly in Commodity Management (BulkStockUpload, NewShipmentPopup, CommodityShipmentPopup, all tab views)
- [ ] Verify paginated fetching kicks in when there are more than 1000 facilities
- [ ] Verify Total Rejected column is no longer shown in stock summary table
- [ ] Verify MultiSelectDropdown options have no visible gap between items
- [ ] Verify MultiSelectDropdown scrollbar behavior with varying option counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Facility searches now automatically load results across multiple pages, providing more complete options in shipment, stock, and transaction workflows.
  * Search results retain accurate totals and loading status during retrieval.

* **Bug Fixes**
  * Improved multi-select dropdown sizing and scrolling for smoother display.
  * Removed rejected stock totals from stock summary tables and summary cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->