### PR TITLE
BUGFIX/HCMPRE-4227 : scope batch session keys per campaign to prevent…

### DIFF
--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/BulkStockUpload.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/BulkStockUpload.js
@@ -43,7 +43,7 @@ const BulkStockUpload = () => {
     result: batchResult,
     reset: resetBatchState,
     abort: abortBatchProcessing,
-  } = useBatchStockCreation({ tenantId });
+  } = useBatchStockCreation({ tenantId, campaignNumber });
 
   // Ref to store original sheet data for error sheet generation
   const originalSheetDataRef = useRef(null);

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityDashboard.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/components/CommodityManagement/CommodityDashboard.js
@@ -14,32 +14,26 @@ import { useCommodityProject } from "./CommodityProjectContext";
 import NewShipmentPopup from "./NewShipmentPopup";
 import useBatchStockCreation from "../../hooks/useBatchStockCreation";
 
-const SHEET_SESSION_KEY = "HCM_BATCH_SHEET_DATA";
-
-/**
- * Persist sheet data + clientRefToRowIndex to sessionStorage
- * so the result sheet can be regenerated after page refresh.
- */
-const saveSheetToSession = (sheetData, clientRefToRowIndex) => {
+const saveSheetToSession = (key, sheetData, clientRefToRowIndex) => {
   try {
-    sessionStorage.setItem(SHEET_SESSION_KEY, JSON.stringify({ sheetData, clientRefToRowIndex }));
+    sessionStorage.setItem(key, JSON.stringify({ sheetData, clientRefToRowIndex }));
   } catch (e) {
     // ignore
   }
 };
 
-const loadSheetFromSession = () => {
+const loadSheetFromSession = (key) => {
   try {
-    const raw = sessionStorage.getItem(SHEET_SESSION_KEY);
+    const raw = sessionStorage.getItem(key);
     return raw ? JSON.parse(raw) : null;
   } catch (e) {
     return null;
   }
 };
 
-const clearSheetSession = () => {
+const clearSheetSession = (key) => {
   try {
-    sessionStorage.removeItem(SHEET_SESSION_KEY);
+    sessionStorage.removeItem(key);
   } catch (e) {
     // ignore
   }
@@ -200,6 +194,9 @@ const CommodityDashboard = () => {
     preset: "cumulative",
   });
 
+  // Scope sheet session key per campaign to prevent cross-campaign data bleed
+  const sheetSessionKey = campaignNumber ? `HCM_BATCH_SHEET_DATA_${campaignNumber}` : "HCM_BATCH_SHEET_DATA";
+
   // --- Batch stock creation (lives here so it persists after popup closes) ---
   const {
     processBatches,
@@ -211,22 +208,35 @@ const CommodityDashboard = () => {
     reset: resetBatchState,
     abort: abortBatchProcessing,
     isRecovered,
-  } = useBatchStockCreation({ tenantId });
+  } = useBatchStockCreation({ tenantId, campaignNumber });
 
   // Store original sheet data and clientRef mapping for result sheet generation
   const originalSheetDataRef = useRef(null);
   const clientRefToRowIndexRef = useRef({});
 
-  // On mount, restore sheet data from sessionStorage if we have recovered batch data
+  // On mount or campaign recovery, restore sheet data from sessionStorage
   useEffect(() => {
     if (isRecovered) {
-      const saved = loadSheetFromSession();
+      const saved = loadSheetFromSession(sheetSessionKey);
       if (saved) {
         originalSheetDataRef.current = saved.sheetData;
         clientRefToRowIndexRef.current = saved.clientRefToRowIndex;
       }
     }
-  }, [isRecovered]);
+  }, [isRecovered, sheetSessionKey]);
+
+  // When campaignNumber changes while the component stays mounted, abort any in-flight
+  // batch and clear the sheet refs so the new campaign starts clean
+  const isFirstMountRef = useRef(true);
+  useEffect(() => {
+    if (isFirstMountRef.current) {
+      isFirstMountRef.current = false;
+      return;
+    }
+    abortBatchProcessing();
+    originalSheetDataRef.current = null;
+    clientRefToRowIndexRef.current = {};
+  }, [campaignNumber]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // --- beforeunload warning: prevent accidental refresh/tab close during processing ---
   useEffect(() => {
@@ -297,20 +307,20 @@ const CommodityDashboard = () => {
     clientRefToRowIndexRef.current = clientRefToRowIndex;
 
     // Persist sheet data to sessionStorage for recovery
-    saveSheetToSession(sheetData, clientRefToRowIndex);
+    saveSheetToSession(sheetSessionKey, sheetData, clientRefToRowIndex);
 
     // Close popup, start batch processing in background
     setShowNewShipmentPopup(false);
     processBatches(stockPayload);
-  }, [processBatches]);
+  }, [processBatches, sheetSessionKey]);
 
   // Clear both session stores on reset
   const handleReset = useCallback(() => {
     resetBatchState();
-    clearSheetSession();
+    clearSheetSession(sheetSessionKey);
     originalSheetDataRef.current = null;
     clientRefToRowIndexRef.current = {};
-  }, [resetBatchState]);
+  }, [resetBatchState, sheetSessionKey]);
 
   // Download result sheet with SUCCESS/CREATION_FAILED per row
   const downloadResultSheet = useCallback(async () => {

--- a/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/useBatchStockCreation.js
+++ b/health/micro-ui-react19/web/packages/modules/campaign-manager/src/hooks/useBatchStockCreation.js
@@ -3,8 +3,6 @@ import { STOCK_BATCH_SIZE, STOCK_SEARCH_MAX_RETRIES, STOCK_SEARCH_RETRY_INTERVAL
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const SESSION_KEY = "HCM_BATCH_STOCK_PROGRESS";
-
 const INITIAL_BATCH_STATUS = {
   total: 0,
   completed: 0,
@@ -18,29 +16,26 @@ const INITIAL_BATCH_STATUS = {
   failedRecords: 0,
 };
 
-/**
- * Persist batch progress to sessionStorage so it survives page refresh.
- */
-const saveToSession = (data) => {
+const saveToSession = (key, data) => {
   try {
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ ...data, updatedAt: Date.now() }));
+    sessionStorage.setItem(key, JSON.stringify({ ...data, updatedAt: Date.now() }));
   } catch (e) {
     // sessionStorage may be full or unavailable; ignore
   }
 };
 
-const loadFromSession = () => {
+const loadFromSession = (key) => {
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
+    const raw = sessionStorage.getItem(key);
     return raw ? JSON.parse(raw) : null;
   } catch (e) {
     return null;
   }
 };
 
-const clearSession = () => {
+const clearSession = (key) => {
   try {
-    sessionStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(key);
   } catch (e) {
     // ignore
   }
@@ -61,9 +56,15 @@ const clearSession = () => {
  *   HCM_BATCH_STARTING, HCM_BATCH_CREATING, HCM_BATCH_VERIFYING,
  *   HCM_BATCH_ALL_SUCCESS, HCM_BATCH_PROCESSING_COMPLETE
  */
-const useBatchStockCreation = ({ tenantId }) => {
-  // Check for recovery data on mount
-  const recoveredData = useRef(loadFromSession());
+const useBatchStockCreation = ({ tenantId, campaignNumber }) => {
+  // Scope session key per campaign so switching campaigns never shows another campaign's recovery banner
+  const sessionKey = campaignNumber ? `HCM_BATCH_STOCK_PROGRESS_${campaignNumber}` : "HCM_BATCH_STOCK_PROGRESS";
+  // Ref keeps callbacks pointing at the current key without closure staleness
+  const sessionKeyRef = useRef(sessionKey);
+  sessionKeyRef.current = sessionKey;
+
+  // Check for recovery data on mount (scoped to this campaign)
+  const recoveredData = useRef(loadFromSession(sessionKey));
 
   const [batchStatus, setBatchStatus] = useState(() => {
     const recovered = recoveredData.current;
@@ -91,6 +92,32 @@ const useBatchStockCreation = ({ tenantId }) => {
 
   const abortRef = useRef(false);
 
+  // When campaignNumber changes while the component is mounted (e.g. user picks a different campaign
+  // without the page navigating to a new route), reload React state from the new campaign's session.
+  // This prevents Campaign A's completed-batch banner from showing on Campaign B's dashboard.
+  // Session storage is NOT cleared here — each campaign's recovery data is preserved under its own key.
+  const isFirstCampaignMountRef = useRef(true);
+  useEffect(() => {
+    if (isFirstCampaignMountRef.current) {
+      isFirstCampaignMountRef.current = false;
+      return; // useState lazy initializers already handled initial load
+    }
+    const newData = loadFromSession(sessionKeyRef.current);
+    if (newData?.batchStatus) {
+      setBatchStatus(newData.batchStatus);
+      setFailedRecords(newData.failedRecords || []);
+      setIsComplete(newData.isComplete || false);
+      setResult(newData.result || null);
+      setIsRecovered(!!(newData.batchStatus && (newData.isComplete || newData.batchStatus.completed > 0)));
+    } else {
+      setBatchStatus({ ...INITIAL_BATCH_STATUS });
+      setFailedRecords([]);
+      setIsComplete(false);
+      setResult(null);
+      setIsRecovered(false);
+    }
+  }, [campaignNumber]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const stockMutationReq = {
     url: `/stock/v1/bulk/_create`,
     params: {},
@@ -103,7 +130,7 @@ const useBatchStockCreation = ({ tenantId }) => {
    * Persist current state to sessionStorage.
    */
   const persistProgress = useCallback((statusOverride, failedOverride, resultOverride, completeOverride) => {
-    saveToSession({
+    saveToSession(sessionKeyRef.current, {
       batchStatus: statusOverride,
       failedRecords: failedOverride,
       result: resultOverride,
@@ -350,7 +377,7 @@ const useBatchStockCreation = ({ tenantId }) => {
     setIsComplete(false);
     setResult(null);
     setIsRecovered(false);
-    clearSession();
+    clearSession(sessionKeyRef.current);
   }, []);
 
   const abort = useCallback(() => {


### PR DESCRIPTION
… cross-campaign recovery banner in Commodity Management

## Choose the appropriate template for your PR:


#### Feature/Bugfix Request

**JIRA ID**  
<!-- Provide the JIRA ID or task reference -->

**Module**  
<!-- Specify the module impacted by the feature -->

**Description**  
<!-- Provide a detailed description of the feature -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch stock upload progress is now saved separately for each campaign.
  * Switching campaigns cancels active processing and prevents data from being restored under the wrong campaign.
  * Returning to a campaign correctly restores its batch upload progress and recovery state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->